### PR TITLE
TEST: ADD-s_expense_request-fields_and_time_state

### DIFF
--- a/s_expense_request/__manifest__.py
+++ b/s_expense_request/__manifest__.py
@@ -7,9 +7,10 @@
     'website': "https://www.suitedoo.com",
     'category': 'Human Resources/Expenses',
     'version': '0.1',
-    'depends': ['hr_expense'],
+    'depends': ['hr_expense','analytic'],
     'data': [
         'security/ir.model.access.csv',
+        'data/ir_cron.xml',
         'views/hr_expense_request.xml',
         'views/inherit_hr_expense.xml',
     ],

--- a/s_expense_request/data/ir_cron.xml
+++ b/s_expense_request/data/ir_cron.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="s_update_expense_request_time_state_cron" model="ir.cron">
+        <field name="name">Update expense request time state</field>
+        <field name="model_id" ref="model_hr_expense_request" />
+        <field name="state">code</field>
+        <field name="code">model.update_expense_request_time_state_cron(15)</field>
+        <field name='interval_number'>1</field>
+        <field name='interval_type'>days</field>
+        <field name="numbercall">-1</field>
+        <field name="nextcall"
+            eval="(DateTime.now().replace(hour=1, minute=0) + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')" />
+    </record>
+</odoo>

--- a/s_expense_request/i18n/es_MX.po
+++ b/s_expense_request/i18n/es_MX.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-14 02:14+0000\n"
-"PO-Revision-Date: 2023-06-14 02:14+0000\n"
+"POT-Creation-Date: 2023-06-20 00:23+0000\n"
+"PO-Revision-Date: 2023-06-20 00:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -52,9 +52,24 @@ msgid "Amount to Check"
 msgstr "Importe por comprobar"
 
 #. module: s_expense_request
-#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form_0
-msgid "Approve"
-msgstr "Aprobar"
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__analytic_distribution
+msgid "Analytic"
+msgstr ""
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__analytic_account_id
+msgid "Analytic Account"
+msgstr "Cuenta analítica"
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__analytic_distribution_search
+msgid "Analytic Distribution Search"
+msgstr ""
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__analytic_precision
+msgid "Analytic Precision"
+msgstr ""
 
 #. module: s_expense_request
 #: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__state__approved
@@ -67,6 +82,11 @@ msgid "Attachment Count"
 msgstr "Número de archivos adjuntos"
 
 #. module: s_expense_request
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
+msgid "Authorize Expense"
+msgstr "Autorizar gasto"
+
+#. module: s_expense_request
 #. odoo-python
 #: code:addons/s_expense_request/models/hr_expense_request.py:0
 #, python-format
@@ -75,13 +95,24 @@ msgstr "No se puede eliminar un registro aprobado."
 
 #. module: s_expense_request
 #: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__state__cancel
-#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form_0
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__product_id
+msgid "Category"
+msgstr "Categoría"
+
+#. module: s_expense_request
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
+msgid "Check Expense"
+msgstr "Comprobar gasto"
+
+#. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__checked_state
 #: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__checked_state__checked
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
 msgid "Checked"
 msgstr "Comprobado"
 
@@ -89,6 +120,12 @@ msgstr "Comprobado"
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__checked_amount
 msgid "Checked Amount"
 msgstr "Importe comprobado"
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__company_id
+#: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__payment_mode__company_account
+msgid "Company"
+msgstr "Empresa"
 
 #. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__create_uid
@@ -103,13 +140,28 @@ msgid "Created on"
 msgstr ""
 
 #. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__time_state
+msgid "Current state"
+msgstr "Estado actual"
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__date_end
+msgid "Date End"
+msgstr "Fecha fin"
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__date_start
+msgid "Date Start"
+msgstr "Fecha inicio"
+
+#. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__description
 msgid "Description"
 msgstr "Descripción"
 
 #. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request_line__name
-#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form_0
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
 msgid "Detail"
 msgstr "Detalle"
 
@@ -121,7 +173,7 @@ msgstr ""
 
 #. module: s_expense_request
 #: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__state__draft
-#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form_0
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
 msgid "Draft"
 msgstr "Borrador"
 
@@ -137,9 +189,19 @@ msgid "Employee"
 msgstr "Empleado"
 
 #. module: s_expense_request
+#: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__payment_mode__own_account
+msgid "Employee (to reimburse)"
+msgstr "Empleado (a reembolsar)"
+
+#. module: s_expense_request
 #: model:ir.model,name:s_expense_request.model_hr_expense
 msgid "Expense"
 msgstr "Gasto"
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__expense_reason
+msgid "Expense Reason"
+msgstr "Motivo del gasto"
 
 #. module: s_expense_request
 #: model:ir.model,name:s_expense_request.model_hr_expense_sheet
@@ -165,9 +227,14 @@ msgid "Expense Requests to Approve"
 msgstr "Solicitude de gasto por aprobar"
 
 #. module: s_expense_request
-#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form_0
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
 msgid "Expense Sheets"
 msgstr "Reportes de gastos"
+
+#. module: s_expense_request
+#: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__time_state__expire
+msgid "Expired"
+msgstr "Vencido"
 
 #. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__message_follower_ids
@@ -217,9 +284,19 @@ msgid "If checked, some messages have a delivery error."
 msgstr ""
 
 #. module: s_expense_request
+#: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__time_state__in_time
+msgid "In time"
+msgstr "A tiempo"
+
+#. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__message_is_follower
 msgid "Is Follower"
 msgstr ""
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__product_has_cost
+msgid "Is product with non zero cost selected"
+msgstr "Se ha seleccionado un producto con un coste distinto de cero"
 
 #. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request____last_update
@@ -306,6 +383,11 @@ msgid "Not checked"
 msgstr "No comprobado"
 
 #. module: s_expense_request
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
+msgid "Notes"
+msgstr "Notas"
+
+#. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__message_needaction_counter
 msgid "Number of Actions"
 msgstr ""
@@ -324,6 +406,11 @@ msgstr ""
 #: model:ir.model.fields,help:s_expense_request.field_hr_expense_request__message_has_error_counter
 msgid "Number of messages with delivery error"
 msgstr ""
+
+#. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__payment_mode
+msgid "Paid By"
+msgstr "Pagado por"
 
 #. module: s_expense_request
 #: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__checked_state__partial
@@ -351,9 +438,24 @@ msgid "Request"
 msgstr "Solicitud"
 
 #. module: s_expense_request
+#: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__request_date
+msgid "Request Date"
+msgstr "Fecha de solicitud"
+
+#. module: s_expense_request
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
+msgid "Request expense"
+msgstr "Solicitar gasto"
+
+#. module: s_expense_request
 #: model_terms:ir.ui.view,arch_db:s_expense_request.s_hr_expense_request_view_search
 msgid "Request to approve"
 msgstr "Solicitudes por aprobar"
+
+#. module: s_expense_request
+#: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__state__requested
+msgid "Requested"
+msgstr "Solicitado"
 
 #. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__activity_user_id
@@ -380,15 +482,32 @@ msgid ""
 msgstr ""
 
 #. module: s_expense_request
-#: model:ir.model.fields.selection,name:s_expense_request.selection__hr_expense_request__state__to_approve
-#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form_0
-msgid "To approve"
-msgstr "Por aprobar"
+#. odoo-python
+#: code:addons/s_expense_request/models/hr_expense_request.py:0
+#, python-format
+msgid "The end date must be later than the initial date"
+msgstr "La fecha de finalización debe ser posterior a la fecha inicial"
+
+#. module: s_expense_request
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
+msgid "Total"
+msgstr ""
+
+#. module: s_expense_request
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
+msgid "Total Checked"
+msgstr "Total comprobado"
 
 #. module: s_expense_request
 #: model:ir.model.fields,help:s_expense_request.field_hr_expense_request__activity_exception_decoration
 msgid "Type of the exception activity on record."
 msgstr ""
+
+#. module: s_expense_request
+#: model:ir.actions.server,name:s_expense_request.s_update_expense_request_time_state_cron_ir_actions_server
+#: model:ir.cron,cron_name:s_expense_request.s_update_expense_request_time_state_cron
+msgid "Update expense request time state"
+msgstr "Actualizar estado de tiempo de solicitud de gastos"
 
 #. module: s_expense_request
 #: model:ir.model.fields,field_description:s_expense_request.field_hr_expense_request__website_message_ids
@@ -406,6 +525,11 @@ msgstr ""
 #, python-format
 msgid "You must provide quantity and price"
 msgstr "Debe proporcionar cantidad y precio"
+
+#. module: s_expense_request
+#: model_terms:ir.ui.view,arch_db:s_expense_request.hr_expense_request_view_form
+msgid "e.g. Lunch with Customer"
+msgstr "Por ejemplo, Comida con cliente"
 
 #. module: s_expense_request
 #: model:ir.model,name:s_expense_request.model_hr_expense_request_line

--- a/s_expense_request/models/hr_expense.py
+++ b/s_expense_request/models/hr_expense.py
@@ -27,7 +27,13 @@ class HrExpense(models.Model):
 
     @api.onchange('expense_request_id')
     def _onchange_expense_request_id(self):
-        self.total_amount = self.expense_request_id.amount if self.expense_request_id else 0
+        if self.expense_request_id: 
+            self.name = self.expense_request_id.name
+            self.total_amount = self.expense_request_id.amount
+            self.product_id = self.expense_request_id.product_id
+            self.employee_id = self.expense_request_id.employee_id
+            self.payment_mode = self.expense_request_id.payment_mode
+
 
     @api.depends('employee_id')
     def _compute_aux_employee_id(self):

--- a/s_expense_request/models/hr_expense.py
+++ b/s_expense_request/models/hr_expense.py
@@ -7,38 +7,6 @@ from odoo.exceptions import ValidationError
 class HrExpense(models.Model):
     _inherit = 'hr.expense'
 
-    aux_employee_id = fields.Many2one(
-        'hr.employee',
-        compute='_compute_aux_employee_id',
-        string='Employee',
-        help='Dummy field to bypass access rights'
-    )
-
-    expense_request_id = fields.Many2one(
-        'hr.expense.request',
-        string='Expense Request',
-        states={
-            'approved': [('readonly', True)],
-            'done': [('readonly', True)]
-        },
-        domain='[("state", "=", "approved"), ("checked_state", "=", "not_checked"), ("employee_id.id", "=", aux_employee_id)]',
-        ondelete="restrict"
-    )
-
-    @api.onchange('expense_request_id')
-    def _onchange_expense_request_id(self):
-        if self.expense_request_id: 
-            self.name = self.expense_request_id.name
-            self.total_amount = self.expense_request_id.amount
-            self.product_id = self.expense_request_id.product_id
-            self.employee_id = self.expense_request_id.employee_id
-            self.payment_mode = self.expense_request_id.payment_mode
-
-
-    @api.depends('employee_id')
-    def _compute_aux_employee_id(self):
-        for rec in self:
-            rec.aux_employee_id = rec.sudo().employee_id
 
 
 class HrExpenseSheet(models.Model):
@@ -51,7 +19,7 @@ class HrExpenseSheet(models.Model):
         states={
             'draft': [('readonly', False)],
         },
-        domain='[("state", "=", "approved"), ("checked_state", "=", "not_checked"), ("employee_id.id", "=", employee_id)]',
+        domain='[("state", "=", "approved"), ("employee_id.id", "=", employee_id)]',
         ondelete="restrict"
     )
 

--- a/s_expense_request/models/hr_expense_request.py
+++ b/s_expense_request/models/hr_expense_request.py
@@ -2,52 +2,116 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_compare
+from datetime import timedelta
+
+INTERVAL_DAYS_CHECK_IN_TIME = 15
 
 
 class HrExpenseRequest(models.Model):
     _name = 'hr.expense.request'
-    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _inherit = ['mail.thread', 'mail.activity.mixin', 'analytic.mixin']
     _description = 'Expense Request'
 
     @api.model
     def _default_employee_id(self):
         return self.env.user.employee_id
 
+    company_id = fields.Many2one(
+        'res.company',
+        string='Company',
+        required=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+        default=lambda self: self.env.company)
+
     name = fields.Char(
         'Name',
         required=True,
         readonly=True,
-        states={
-            'draft': [('readonly', False)]
-        }
+        tracking=True,
+        states={'draft': [('readonly', False)]},
+    )
+    expense_reason = fields.Char(
+        'Expense Reason',
+        tracking=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
     )
     description = fields.Text(
         'Description',
-        states={
-            'draft': [('readonly', False)]
-        }
+        tracking=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+    )
+    request_date = fields.Date(
+        'Request Date',
+        tracking=True,
+        default=lambda self: fields.Date.context_today(self),
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+    )
+    date_start = fields.Date(
+        'Date Start',
+        tracking=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+    )
+    date_end = fields.Date(
+        'Date End',
+        tracking=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+    )
+    analytic_account_id = fields.Many2one(
+        'account.analytic.account',
+        string='Analytic Account',
+        tracking=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
     )
     amount = fields.Float('Amount', compute='_set_amount', store=True)
     checked_amount = fields.Float(
         compute='_set_checked_state', string='Checked Amount', store=True)
+    product_id = fields.Many2one(
+        'product.product',
+        string='Category',
+        tracking=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+        domain="[('can_be_expensed', '=', True), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        ondelete='restrict'
+    )
     employee_id = fields.Many2one(
         'hr.employee',
         string='Employee',
         required=True,
         default=_default_employee_id,
-        readonly=True,
         tracking=True,
+        readonly=True,
         states={'draft': [('readonly', False)]},
     )
+    payment_mode = fields.Selection(
+        [
+            ("own_account", "Employee (to reimburse)"),
+            ("company_account", "Company")
+        ],
+        default='own_account',
+        tracking=True,
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+        string="Paid By")
+
     state = fields.Selection(
         [
             ('draft', 'Draft'),
-            ('to_approve', 'To approve'),
+            ('requested', 'Requested'),
             ('approved', 'Approved'),
             ('cancel', 'Cancel')
         ],
         'State',
-        default='draft'
+        default='draft',
+        tracking=True
     )
     checked_state = fields.Selection(
         [
@@ -60,14 +124,22 @@ class HrExpenseRequest(models.Model):
         compute='_set_checked_state',
         store=True
     )
+    time_state = fields.Selection(
+        [
+            ('in_time', 'In time'),
+            ('expire', 'Expired')
+        ],
+        string='Current state',
+        default='in_time',
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+    )
     line_ids = fields.One2many(
         'hr.expense.request.line',
         'request_id',
         'Lines',
         readonly=True,
-        states={
-            'draft': [('readonly', False)]
-        }
+        states={'draft': [('readonly', False)]},
     )
     expense_sheet_ids = fields.One2many(
         'hr.expense.sheet',
@@ -75,17 +147,34 @@ class HrExpenseRequest(models.Model):
         'Expense Reports',
         domain=[('state', 'in', ('approve', 'post', 'done'))]
     )
+    product_has_cost = fields.Boolean(
+        "Is product with non zero cost selected", compute='_set_product_has_cost')
 
     @api.constrains('line_ids')
     def _constrains_line_ids(self):
-        for line in self.line_ids:
-            if not line.quantity or not line.price_unit:
-                raise ValidationError(_('You must provide quantity and price'))
+        for request in self:
+            for line in request.line_ids:
+                if not line.quantity or not line.price_unit:
+                    raise ValidationError(
+                        _('You must provide quantity and price'))
+
+    @api.constrains('date_start', 'date_end')
+    def _constrains_dates(self):
+        for request in self:
+            if request.date_start > request.date_end:
+                raise ValidationError(
+                    _('The end date must be later than the initial date'))
 
     @api.depends('line_ids')
     def _set_amount(self):
         for rec in self:
             rec.amount = sum([l.amount for l in rec.line_ids])
+
+    @api.depends('product_id')
+    def _set_product_has_cost(self):
+        for expense_req in self:
+            expense_req.product_has_cost = expense_req.product_id and (float_compare(
+                expense_req.product_id.standard_price, 0.0, precision_digits=2) != 0)
 
     @api.depends('expense_sheet_ids.state')
     def _set_checked_state(self):
@@ -98,7 +187,7 @@ class HrExpenseRequest(models.Model):
                         rec.checked_amount = rec.amount
                     else:
                         rec.checked_amount = ck_amount
-                        
+
                     if ck_amount == 0 and rec.checked_state != 'not_checked':
                         rec.checked_state = 'not_checked'
                     elif ck_amount < rec.amount and rec.checked_state != 'partial':
@@ -112,8 +201,19 @@ class HrExpenseRequest(models.Model):
                 raise ValidationError(_('Can not delete a approved record.'))
         return super().unlink()
 
-    def action_to_approve(self):
-        self.state = 'to_approve'
+    def action_check_expense_state(self):
+        """
+        Actualzar el estado de la comprobación del gasto y si la tarea 
+        está en tiempo, por si por algún motivo no se actualizara con 
+        los campos compute o el cron 
+        """
+        self._set_checked_state()
+        interval_date = fields.Date.today() + timedelta(days=-INTERVAL_DAYS_CHECK_IN_TIME)
+        if self.date_end < interval_date and self.checked_state == 'not_checked' and self.time_state != 'expire':
+            self.time_state = 'expire'
+
+    def action_request(self):
+        self.state = 'requested'
 
     def action_approved(self):
         self.state = 'approved'
@@ -123,6 +223,25 @@ class HrExpenseRequest(models.Model):
 
     def action_draft(self):
         self.state = 'draft'
+
+    def action_draft(self):
+        self.state = 'draft'
+
+    @api.model
+    def update_expense_request_time_state_cron(self, days=INTERVAL_DAYS_CHECK_IN_TIME):
+        today = fields.Date.today()
+        # Chequear solicitudes de los 15 días anteriores a los últimos 15
+        # días para evitar que se chequeen todas las tareas y que
+        # se queden tareas sin verificar
+        # TODO: mejorar esto
+        expired_requests = self.search([
+            ('date_end', '<=', today + timedelta(days=-days)),
+            ('date_start', '<=', today +
+             timedelta(days=-(2*days))),
+        ])
+        for req in expired_requests:
+            if req.checked_state == 'not_checked' and req.time_state != 'expire':
+                req.time_state = 'expire'
 
 
 class HrExpenseRequest(models.Model):

--- a/s_expense_request/models/hr_expense_request.py
+++ b/s_expense_request/models/hr_expense_request.py
@@ -176,7 +176,7 @@ class HrExpenseRequest(models.Model):
             expense_req.product_has_cost = expense_req.product_id and (float_compare(
                 expense_req.product_id.standard_price, 0.0, precision_digits=2) != 0)
 
-    @api.depends('expense_sheet_ids.state')
+    @api.depends('expense_sheet_ids')
     def _set_checked_state(self):
         for rec in self:
             if rec.expense_sheet_ids:

--- a/s_expense_request/views/hr_expense_request.xml
+++ b/s_expense_request/views/hr_expense_request.xml
@@ -12,59 +12,94 @@
                     <field name="amount" />
                     <field name="checked_amount" />
                     <field name="state" />
+                    <field name="time_state" />
                 </tree>
             </field>
         </record>
 
-        <record id="hr_expense_request_view_form_0" model="ir.ui.view">
+        <record id="hr_expense_request_view_form" model="ir.ui.view">
             <field name="name">hr.expense.request.view.form</field>
             <field name="model">hr.expense.request</field>
             <field name="arch" type="xml">
                 <form string="">
                     <header>
                         <button
-                            name="action_to_approve"
-                            string="To approve"
+                            name="action_check_expense_state"
+                            string="Check Expense"
                             class="btn btn-primary"
                             type="object"
-                            attrs="{'invisible': [('state', 'not in', ('draft'))]}" />
+                            attrs="{'invisible': [('state', 'not in', ['approved'] )]}" />
+                        <button
+                            name="action_request"
+                            string="Request expense"
+                            class="btn btn-primary"
+                            type="object"
+                            attrs="{'invisible': [('state', 'not in', ['draft'] )]}" />
                         <button
                             name="action_approved"
-                            string="Approve"
+                            string="Authorize Expense"
                             class="btn btn-primary"
                             type="object"
-                            attrs="{'invisible': [('state', 'not in', ('to_approve'))]}"
+                            attrs="{'invisible': [('state', 'not in', ['requested'] )]}"
                             groups="hr_expense.group_hr_expense_team_approver" />
                         <button
                             name="action_cancel"
                             string="Cancel"
                             class="btn btn-secondary"
                             type="object"
-                            attrs="{'invisible': [('state', 'in', ('cancel'))]}" />
+                            attrs="{'invisible': [('state', 'in', ['cancel'] )]}" />
                         <button
                             name="action_draft"
                             string="Draft"
                             class="btn btn-secondary"
                             type="object"
-                            attrs="{'invisible': [('state', 'in', ('draft'))]}" />
+                            attrs="{'invisible': [('state', 'in', ['draft'] )]}" />
+                        <button
+                            name="action_draft"
+                            string="Draft"
+                            class="btn btn-secondary"
+                            type="object"
+                            attrs="{'invisible': [('state', 'not in', ('approved',))]}" />
                         <field
                             name="state"
                             widget="statusbar"
-                            statusbar_visible="draft,to_approve,approved" />
+                            statusbar_visible="draft,requested,approved" />
                     </header>
                     <sheet>
+                        <field name="company_id" invisible="True" />
+                        <field name="product_has_cost" invisible="True" />
+
+                        <div class="oe_title">
+                            <label for="name" />
+                            <h1>
+                                <field name="name" placeholder="e.g. Lunch with Customer" />
+                            </h1>
+                        </div>
                         <group>
                             <group name="left_group">
-                                <field name="name" />
-                                <field name="employee_id" groups="hr_expense.group_hr_expense_team_approver" />
-                                <field name="description" attrs="{'required': 0}" />
+                                <field name="product_id" required="True"
+                                    context="{'default_can_be_expensed': 1, 'tree_view_ref': 'hr_expense.product_product_expense_tree_view', 'form_view_ref': 'hr_expense.product_product_expense_form_view'}" />
+                                <field name="amount" string="Total" />
+                                <field name="checked_amount" string="Total Checked" />
+                                <field name="checked_state" string="Checked" />
+                                <field name="employee_id" />
+                                <label id="lo" for="payment_mode"
+                                    attrs="{'invisible': [('product_has_cost', '=', True)]}" />
+                                <div id="payment_mode"
+                                    attrs="{'invisible': [('product_has_cost', '=', True)]}">
+                                    <field name="payment_mode" widget="radio" nolabel="1" />
+                                </div>
                             </group>
                             <group name="right_group">
-                                <field name="checked_state" />
-                                <field name="amount" />
-                                <field name="checked_amount" />
+                                <field name="request_date" />
+                                <field name="date_start" />
+                                <field name="date_end" />
+                                <field name="expense_reason" />
+                                <field name="time_state" readonly="1" force_save="1"/>
+                                <field name="analytic_account_id" />
                             </group>
                         </group>
+                        <field name="description" nolabel="1" colspan="2" placeholder="Notes" />
                         <notebook>
                             <page name="line_ids" string="Detail">
                                 <field name="line_ids">
@@ -98,8 +133,10 @@
                 <search string="">
                     <field name="name" />
                     <field name="employee_id" />
-                    <filter string="My Requests" name="my_requests" domain="[('employee_id.user_id', '=', uid)]" />
-                    <filter string="Request to approve" name="to_approve_requests" domain="[('state', '=', 'to_approve')]" />
+                    <filter string="My Requests" name="my_requests"
+                        domain="[('employee_id.user_id', '=', uid)]" />
+                    <filter string="Request to approve" name="to_approve_requests"
+                        domain="[('state', '=', 'requested')]" />
                 </search>
             </field>
         </record>

--- a/s_expense_request/views/inherit_hr_expense.xml
+++ b/s_expense_request/views/inherit_hr_expense.xml
@@ -6,11 +6,11 @@
             <field name="model">hr.expense</field>
             <field name="inherit_id" ref="hr_expense.hr_expense_view_form" />
             <field name="arch" type="xml">
-                <xpath expr="//label[@for='product_id']" position="before">
+                <xpath expr="//label[@for='name']" position="before">
                     <field name="aux_employee_id" invisible="1" />
                     <label for="expense_request_id" />
                     <div>
-                        <field name="expense_request_id" />
+                        <field name="expense_request_id" class="w-100"/>
                     </div>
                 </xpath>
             </field>
@@ -23,8 +23,10 @@
             <field name="arch" type="xml">
                 <field name="accounting_date" position="after">
                     <field name="expense_request_id" />
-                    <field name="amount_to_check" attrs="{'invisible': [('expense_request_id', '=', False)]}" />
-                    <field name="un_checked_amount" attrs="{'invisible': [('expense_request_id', '=', False)]}" />
+                    <field name="amount_to_check"
+                        attrs="{'invisible': [('expense_request_id', '=', False)]}" />
+                    <field name="un_checked_amount"
+                        attrs="{'invisible': [('expense_request_id', '=', False)]}" />
                 </field>
             </field>
         </record>

--- a/s_expense_request/views/inherit_hr_expense.xml
+++ b/s_expense_request/views/inherit_hr_expense.xml
@@ -1,20 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <record id="inherit_hr_expense_view_form" model="ir.ui.view">
+        <!-- <record id="inherit_hr_expense_view_form" model="ir.ui.view">
             <field name="name">inherit.hr.expense.view.form</field>
             <field name="model">hr.expense</field>
             <field name="inherit_id" ref="hr_expense.hr_expense_view_form" />
             <field name="arch" type="xml">
-                <xpath expr="//label[@for='name']" position="before">
-                    <field name="aux_employee_id" invisible="1" />
-                    <label for="expense_request_id" />
-                    <div>
-                        <field name="expense_request_id" class="w-100"/>
-                    </div>
-                </xpath>
+
             </field>
-        </record>
+        </record> -->
 
         <record id="s_view_hr_expense_sheet_form_inherit" model="ir.ui.view">
             <field name="name">s.view.hr.expense.sheet.form.inherit</field>


### PR DESCRIPTION
Adicionar campos categoría, modo de pago, fecha de la solicitud, fecha inicio y fecha fin, motivo del gasto, estado actual (a tiempo, vencido) Obtener gastos de la solicitud desde el gasto
Tarea programada que marca las solicitudes como vencidas si no se han registrado gastos en 15 días

DESARROLLO: 6 primera etapa