### PR TITLE
PRD: ADD|s_analytic|for_analytic_custom|DEV_ABT|16.0

### DIFF
--- a/s_analytic/__init__.py
+++ b/s_analytic/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/s_analytic/__manifest__.py
+++ b/s_analytic/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Analytic Account Features",
+    'summary': """Features for Analytic Account""",
+    'description': """Features Analytic Account""",
+    'author': "SUITEDOO",
+    'website': "https://www.suitedoo.com",
+    'category': 'Accounting/Accounting',
+    'version': '0.1',
+    'depends': ['analytic'],
+    'data': [
+        'views/inherit_analytic_account_views.xml',
+    ],
+    'installable': True,
+    'auto_install': False
+}

--- a/s_analytic/i18n/es_MX.po
+++ b/s_analytic/i18n/es_MX.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* s_analytic
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-06-17 14:25+0000\n"
+"PO-Revision-Date: 2023-06-17 14:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: s_analytic
+#: model:ir.model,name:s_analytic.model_account_analytic_account
+msgid "Analytic Account"
+msgstr "Cuenta analítica"
+
+#. module: s_analytic
+#: model_terms:ir.ui.view,arch_db:s_analytic.s_inherit_account_analytic_account_view_form
+#: model_terms:ir.ui.view,arch_db:s_analytic.s_inherit_account_analytic_account_view_tree
+#: model_terms:ir.ui.view,arch_db:s_analytic.s_inherit_account_analytic_plan_view_form
+#: model_terms:ir.ui.view,arch_db:s_analytic.s_inherit_account_analytic_plan_view_tree
+msgid "Identification"
+msgstr "Identificación"

--- a/s_analytic/models/__init__.py
+++ b/s_analytic/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import inherit_analytic_account

--- a/s_analytic/models/inherit_analytic_account.py
+++ b/s_analytic/models/inherit_analytic_account.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+from odoo.osv import expression
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    def init(self):
+        """
+        Es necesario incluir el id y el plan en los campos que admite el name_search
+        """
+        res = super().init()
+        new_fields = ['id', 'plan_id.id', 'plan_id.name']
+        for nf in new_fields:
+            if nf not in self._rec_names_search:
+                self._rec_names_search.append(nf)
+        return res
+
+    def name_get(self):
+        result = []
+        for record in self:
+            result.append(
+                (record.id, "[%(p_id)s - %(a_id)s] [%(p_name)s - %(a_name)s]" % {
+                    "p_id": record.plan_id.id,
+                    "a_id": record.id,
+                    "p_name": record.plan_id.name,
+                    "a_name": record.name,
+                })
+            )
+        return result
+
+    def get_full_search_domain(self, name):
+        if name:
+            domains = [
+                [('name', 'ilike', name)],
+                [('plan_id.name', 'ilike', name)],
+            ]
+            for part in name.split(' '):
+                try:
+                    domains.append([('id', '=', int(part))])
+                    domains.append([('plan_id.id', '=', int(part))])
+                except:
+                    pass
+            return expression.OR(domains)
+        return []
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        """
+        Se busca en el nombre y el id de la cuenta y el plan
+        """
+        new_args = None
+        if name:
+            new_args = self.get_full_search_domain(name)
+            if args:
+                new_args = expression.OR(args, new_args)
+        return super().name_search(name, args, operator, limit)
+
+    @api.model
+    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, **read_kwargs):
+        """
+        Desde el widget de compras se usa search_read en lugar de name_get, por lo tanto hay que reemplazar 
+        la expresión del dominio asodiada al nombre para que se bueque por el nombre y el id de la cuenta y el plan
+        """
+        name_domain = None
+        if domain:
+            for leaf in domain:
+                if leaf[0] == 'name' and leaf[2]:
+                    name_domain = self.get_full_search_domain(leaf[2])
+                    break
+
+        if name_domain:
+            new_domain = []
+            for leaf in domain:
+                if leaf[0] != 'name':
+                    new_domain.append(leaf)
+                else:
+                    for name_leaf in name_domain:
+                        new_domain.append(name_leaf)
+            domain = new_domain
+
+        return super().search_read(domain, fields, offset, limit, order, **read_kwargs)

--- a/s_analytic/security/ir.model.access.csv
+++ b/s_analytic/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/s_analytic/views/inherit_analytic_account_views.xml
+++ b/s_analytic/views/inherit_analytic_account_views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="s_inherit_account_analytic_plan_view_tree" model="ir.ui.view">
+            <field name="name">s.inherit.account.analytic.plan.view.tree</field>
+            <field name="model">account.analytic.plan</field>
+            <field name="inherit_id" ref="analytic.account_analytic_plan_tree_view" />
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="id" string="Identification"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="s_inherit_account_analytic_plan_view_form" model="ir.ui.view">
+            <field name="name">s.inherit.account.analytic.plan.view.form</field>
+            <field name="model">account.analytic.plan</field>
+            <field name="inherit_id" ref="analytic.account_analytic_plan_form_view" />
+            <field name="arch" type="xml">
+                <field name="parent_id" position="before">
+                    <field name="id" string="Identification" />
+                </field>
+            </field>
+        </record>
+
+        <record id="s_inherit_account_analytic_account_view_tree" model="ir.ui.view">
+            <field name="name">s.inherit.account.analytic.account.view.tree</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_account_list" />
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="id" string="Identification"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="s_inherit_account_analytic_account_view_form" model="ir.ui.view">
+            <field name="name">s.inherit.account.analytic.account.view.form</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="before">
+                    <field name="id" string="Identification" />
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Mostrar el id de base de datos como identificador en las vistas de planes y cuentas analíticas Sobrescribir el name_get para mostrar el nombre en el formato indicado desde los select Funcionalidad para obtener el dominio de búsqueda completo Adicionar los campos de búsqueda a _rec_names_search para poder utilizarlos en name_search Sobrescribir search_read que es el método que se usa desde el widget de compras