### PR TITLE
TEST: ADD-s_sh-customs_for_employees

### DIFF
--- a/s_hr/__init__.py
+++ b/s_hr/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/s_hr/__manifest__.py
+++ b/s_hr/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Employee Custom Features",
+    'summary': """Employee Custom Features""",
+    'description': """Employee Custom Features""",
+    'author': "SUITEDOO",
+    'website': "https://www.suitedoo.com",
+    'category': 'Human Resources/Employees',
+    'version': '0.1',
+    'depends': ['stock_account', 'purchase', 'sale', 'analytic'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/inherit_hr_employee.xml',
+        'views/inherit_res_partner.xml',
+        'views/inherit_res_country.xml',
+        'views/hr_area.xml',
+        'views/hr_speciality.xml',
+        'views/hr_management_area.xml',
+        'views/hr_activity_type.xml',
+    ],
+    'installable': True,
+    'auto_install': False
+}

--- a/s_hr/i18n/es_MX.po
+++ b/s_hr/i18n/es_MX.po
@@ -1,0 +1,182 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* s_hr
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-02 21:03+0000\n"
+"PO-Revision-Date: 2023-07-02 21:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: s_hr
+#: model:ir.model,name:s_hr.model_hr_activity_type
+msgid "Activity type"
+msgstr "Tipo de actividad"
+
+#. module: s_hr
+#: model:ir.actions.act_window,name:s_hr.s_hr_activity_type_action
+#: model:ir.ui.menu,name:s_hr.hr_area_menu
+msgid "Activity types"
+msgstr "Tipos de actividad"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_employee__area_id
+msgid "Area"
+msgstr "Área"
+
+#. module: s_hr
+#: model:ir.actions.act_window,name:s_hr.s_hr_area_action
+msgid "Areas"
+msgstr "Áreas"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_employee__city
+msgid "City"
+msgstr "Ciudad"
+
+#. module: s_hr
+#: model:ir.model,name:s_hr.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: s_hr
+#: model:ir.model,name:s_hr.model_res_country_state
+msgid "Country state"
+msgstr "Estado"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type__create_uid
+#: model:ir.model.fields,field_description:s_hr.field_hr_area__create_uid
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area__create_uid
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type__create_date
+#: model:ir.model.fields,field_description:s_hr.field_hr_area__create_date
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area__create_date
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.actions.act_window,name:s_hr.s_res_partner_customer_action
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: s_hr
+#: model:ir.ui.menu,name:s_hr.s_res_partner_customer_menu
+#: model_terms:ir.ui.view,arch_db:s_hr.s_inherit_res_partner_view_search
+msgid "Customers"
+msgstr "Clientes"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type__display_name
+#: model:ir.model.fields,field_description:s_hr.field_hr_area__display_name
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area__display_name
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.model,name:s_hr.model_hr_employee
+msgid "Employee"
+msgstr "Empleado"
+
+#. module: s_hr
+#: model:ir.model,name:s_hr.model_hr_speciality
+msgid "Employee Speciality"
+msgstr "Especialidad del empleado"
+
+#. module: s_hr
+#: model:ir.actions.act_window,name:s_hr.s_res_country_state_federal_entity_action
+#: model:ir.ui.menu,name:s_hr.s_res_country_state_federal_entity_menu
+msgid "Federal Entities"
+msgstr "Entidades federativas"
+
+#. module: s_hr
+#: model:ir.model,name:s_hr.model_hr_area
+msgid "Humar Resources Area"
+msgstr "Área de recursos humanos"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type__id
+#: model:ir.model.fields,field_description:s_hr.field_hr_area__id
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area__id
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality__id
+msgid "ID"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_res_partner__is_customer
+#: model:ir.model.fields,field_description:s_hr.field_res_users__is_customer
+msgid "Is customer"
+msgstr "Es cliente"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type____last_update
+#: model:ir.model.fields,field_description:s_hr.field_hr_area____last_update
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area____last_update
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type__write_uid
+#: model:ir.model.fields,field_description:s_hr.field_hr_area__write_uid
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area__write_uid
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type__write_date
+#: model:ir.model.fields,field_description:s_hr.field_hr_area__write_date
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area__write_date
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.model,name:s_hr.model_hr_management_area
+#: model:ir.model.fields,field_description:s_hr.field_hr_employee__management_area_id
+msgid "Management Area"
+msgstr "Dirección"
+
+#. module: s_hr
+#: model:ir.actions.act_window,name:s_hr.s_hr_management_area_action
+#: model:ir.ui.menu,name:s_hr.hr_management_area_menu
+msgid "Management Areas"
+msgstr "Direcciones"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_activity_type__name
+#: model:ir.model.fields,field_description:s_hr.field_hr_area__name
+#: model:ir.model.fields,field_description:s_hr.field_hr_management_area__name
+#: model:ir.model.fields,field_description:s_hr.field_hr_speciality__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_employee__is_regional
+msgid "Regional"
+msgstr ""
+
+#. module: s_hr
+#: model:ir.actions.act_window,name:s_hr.s_hr_speciality_action
+#: model:ir.ui.menu,name:s_hr.hr_speciality_menu
+msgid "Specialities"
+msgstr "Especialidades"
+
+#. module: s_hr
+#: model:ir.model.fields,field_description:s_hr.field_hr_employee__speciality_id
+msgid "Speciality"
+msgstr "Especialiad"

--- a/s_hr/models/__init__.py
+++ b/s_hr/models/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from . import inherit_hr_employee
+from . import hr_area
+from . import hr_speciality
+from . import inherit_hr_employee
+from . import hr_management_area
+from . import inherit_res_partner
+from . import inherit_res_country
+from . import hr_activity_type

--- a/s_hr/models/hr_activity_type.py
+++ b/s_hr/models/hr_activity_type.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+
+class ActivityType(models.Model):
+    _name = 'hr.activity.type'
+    _description = 'Activity type'
+
+    name = fields.Char('Name')

--- a/s_hr/models/hr_area.py
+++ b/s_hr/models/hr_area.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+class HrArea(models.Model):
+    _name = 'hr.area'
+    _description = 'Humar Resources Area'
+    
+    name = fields.Char('Name')

--- a/s_hr/models/hr_management_area.py
+++ b/s_hr/models/hr_management_area.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+class HrBusinessManagementArea(models.Model):
+    _name = 'hr.management.area'
+    _description = 'Management Area'
+    
+    name = fields.Char('Name')

--- a/s_hr/models/hr_speciality.py
+++ b/s_hr/models/hr_speciality.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+class HrSpeciality(models.Model):
+    _name = 'hr.speciality'
+    _description = 'Employee Speciality'
+    
+    name = fields.Char('Name')

--- a/s_hr/models/inherit_hr_employee.py
+++ b/s_hr/models/inherit_hr_employee.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    area_id = fields.Many2one('hr.area', string='Area')
+    speciality_id = fields.Many2one('hr.speciality', string='Speciality')
+    management_area_id = fields.Many2one(
+        'hr.management.area', string='Management Area')
+
+    is_regional = fields.Boolean('Regional')
+    city = fields.Char('City')

--- a/s_hr/models/inherit_res_country.py
+++ b/s_hr/models/inherit_res_country.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+from odoo.osv import expression
+
+
+class ResCountryState(models.Model):
+    _inherit = 'res.country.state'
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        if self.env.context.get('filter_current_company'):
+            company_country_states_domain = [
+                ('country_id', '=', self.env.company.country_id.id)]
+            if not args:
+                args = company_country_states_domain
+            else:
+                args = expression.AND([args, company_country_states_domain])
+        return super().search(args, offset, limit, order, count)

--- a/s_hr/models/inherit_res_partner.py
+++ b/s_hr/models/inherit_res_partner.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    is_customer = fields.Boolean('Is customer')

--- a/s_hr/security/ir.model.access.csv
+++ b/s_hr/security/ir.model.access.csv
@@ -1,0 +1,12 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_area,access.hr.area,model_hr_area,base.group_user,1,0,0,0
+access_hr_area_manager,access.hr.area.manager,model_hr_area,hr.group_hr_manager,1,1,1,1
+
+access_hr_speciality,access.hr.speciality,model_hr_speciality,base.group_user,1,0,0,0
+access_hr_speciality_manager,access.hr.speciality.manager,model_hr_speciality,hr.group_hr_manager,1,1,1,1
+
+access_hr_management_area,access.hr.management.area,model_hr_management_area,base.group_user,1,0,0,0
+access_hr_management_area_manager,access.hr.management.area.manager,model_hr_management_area,hr.group_hr_manager,1,1,1,1
+
+access_hr_activity_type,access.hr.activity.type,model_hr_activity_type,base.group_user,1,0,0,0
+access_hr_activity_type_manager,access.activity.type.manager,model_hr_activity_type,hr.group_hr_manager,1,1,1,1

--- a/s_hr/views/hr_activity_type.xml
+++ b/s_hr/views/hr_activity_type.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_hr_activity_type_view_tree" model="ir.ui.view">
+            <field name="name">hr.activity.type.view.tree</field>
+            <field name="model">hr.activity.type</field>
+            <field name="arch" type="xml">
+                <tree string="">
+                    <field name="name" />
+                </tree>
+            </field>
+        </record>
+
+        <record id="s_hr_activity_type_view_form" model="ir.ui.view">
+            <field name="name">hr.activity.type.view.form</field>
+            <field name="model">hr.activity.type</field>
+            <field name="arch" type="xml">
+                <form string="">
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name" />
+                            </group>
+                            <group>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="s_hr_activity_type_action" model="ir.actions.act_window">
+            <field name="name">Activity types</field>
+            <field name="res_model">hr.activity.type</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        
+        <menuitem
+            id="hr_area_menu"
+            name="Activity types"
+            action="s_hr_activity_type_action"
+            parent="hr.menu_config_employee"
+            groups="base.group_user"
+            sequence="25" />
+
+    </data>
+</odoo>

--- a/s_hr/views/hr_area.xml
+++ b/s_hr/views/hr_area.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_hr_area_view_tree" model="ir.ui.view">
+            <field name="name">hr.area.view.tree</field>
+            <field name="model">hr.area</field>
+            <field name="arch" type="xml">
+                <tree string="">
+                    <field name="name" />
+                </tree>
+            </field>
+        </record>
+
+        <record id="s_hr_area_view_form" model="ir.ui.view">
+            <field name="name">hr.area.view.form</field>
+            <field name="model">hr.area</field>
+            <field name="arch" type="xml">
+                <form string="">
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name" />
+                            </group>
+                            <group>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="s_hr_area_action_0" model="ir.actions.act_window">
+            <field name="name">Areas</field>
+            <field name="res_model">hr.area</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        
+        <menuitem
+            id="hr_area_menuitem"
+            name="Areas"
+            action="s_hr_area_action_0"
+            parent="hr.menu_config_employee"
+            groups="base.group_user"
+            sequence="20" />
+
+    </data>
+</odoo>

--- a/s_hr/views/hr_management_area.xml
+++ b/s_hr/views/hr_management_area.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_hr_management_area_view_tree" model="ir.ui.view">
+            <field name="name">hr.management.area.view.tree</field>
+            <field name="model">hr.management.area</field>
+            <field name="arch" type="xml">
+                <tree string="">
+                    <field name="name" />
+                </tree>
+            </field>
+        </record>
+
+        <record id="s_hr_management_area_view_form" model="ir.ui.view">
+            <field name="name">hr.management.area.view.form</field>
+            <field name="model">hr.management.area</field>
+            <field name="arch" type="xml">
+                <form string="">
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name" />
+                            </group>
+                            <group>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="s_hr_management_area_action" model="ir.actions.act_window">
+            <field name="name">Management Areas</field>
+            <field name="res_model">hr.management.area</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        
+        <menuitem
+            id="hr_management_area_menu"
+            name="Management Areas"
+            action="s_hr_management_area_action"
+            parent="hr.menu_config_employee"
+            groups="base.group_user"
+            sequence="22" />
+
+    </data>
+</odoo>

--- a/s_hr/views/hr_speciality.xml
+++ b/s_hr/views/hr_speciality.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_hr_speciality_view_tree" model="ir.ui.view">
+            <field name="name">hr.speciality.view.tree</field>
+            <field name="model">hr.speciality</field>
+            <field name="arch" type="xml">
+                <tree string="">
+                    <field name="name" />
+                </tree>
+            </field>
+        </record>
+
+        <record id="s_hr_speciality_view_form" model="ir.ui.view">
+            <field name="name">hr.speciality.view.form</field>
+            <field name="model">hr.speciality</field>
+            <field name="arch" type="xml">
+                <form string="">
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name" />
+                            </group>
+                            <group>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="s_hr_speciality_action" model="ir.actions.act_window">
+            <field name="name">Specialities</field>
+            <field name="res_model">hr.speciality</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        
+        <menuitem
+            id="hr_speciality_menu"
+            name="Specialities"
+            action="s_hr_speciality_action"
+            parent="hr.menu_config_employee"
+            groups="base.group_user"
+            sequence="21" />
+
+    </data>
+</odoo>

--- a/s_hr/views/inherit_hr_employee.xml
+++ b/s_hr/views/inherit_hr_employee.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_hr_employee_view_form" model="ir.ui.view">
+            <field name="name">hr.employee.view.form</field>
+            <field name="model">hr.employee</field>
+            <field name="inherit_id" ref="hr.view_employee_form" />
+            <field name="arch" type="xml">
+                <field name="department_id" position="before">
+                    <field name="area_id" />
+                    <field name="speciality_id" />
+                    <field name="management_area_id" />
+                </field>
+                <field name="coach_id" position="after">
+                    <field name="is_regional" />
+                    <field name="city" />
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/s_hr/views/inherit_res_country.xml
+++ b/s_hr/views/inherit_res_country.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="s_res_country_state_federal_entity_action" model="ir.actions.act_window">
+            <field name="name">Federal Entities</field>
+            <field name="res_model">res.country.state</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{'filter_current_company': True}</field>
+        </record>
+
+        <menuitem
+            id="s_res_country_state_federal_entity_menu"
+            name="Federal Entities"
+            action="s_res_country_state_federal_entity_action"
+            parent="hr.menu_config_employee"
+            groups="base.group_user"
+            sequence="24" />
+    </data>
+</odoo>

--- a/s_hr/views/inherit_res_partner.xml
+++ b/s_hr/views/inherit_res_partner.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_res_partner_view_form" model="ir.ui.view">
+            <field name="name">s.inherit.res.partner.view.form</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='sales_purchases']//field[@name='user_id']"
+                    position="before">
+                    <field name="is_customer" />
+                </xpath>
+            </field>
+        </record>
+
+        <record id="s_inherit_res_partner_view_search" model="ir.ui.view">
+            <field name="name">res.partner.view.search</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_res_partner_filter" />
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='type_company']" position="after">
+                    <filter name="filter_is_customer" string="Customers"
+                        domain="[('is_customer', '=', True)]" />
+                </xpath>
+            </field>
+        </record>
+
+        <record id="s_res_partner_customer_action" model="ir.actions.act_window">
+            <field name="name">Customer</field>
+            <field name="res_model">res.partner</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{'search_default_filter_is_customer': True}</field>
+        </record>
+
+        <menuitem
+            id="s_res_partner_customer_menu"
+            name="Customers"
+            action="s_res_partner_customer_action"
+            parent="hr.menu_config_employee"
+            groups="base.group_user"
+            sequence="23" />
+
+    </data>
+</odoo>


### PR DESCRIPTION
Adicionar catálogos con vistas y menús para:
-Areas
-Especialidades
-Direcciones
-Clientes (res.partner: se adiciona un campo para indicar que es cliente y se crea el filtro en la vista search) -Etidades federativas (res.country.state: se pasa un valor por contexto desde el action y en el search se filtran los estados del país de la compañía actual) -Tipo de actividad
Se adicionan los campos al empleado, modelo y vista