### PR TITLE
TEST:  Cobros – Tipo de Cambio

### DIFF
--- a/s_custom_sale_rate/__init__.py
+++ b/s_custom_sale_rate/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/s_custom_sale_rate/__manifest__.py
+++ b/s_custom_sale_rate/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Custom Sale Exchange Rate",
+    'summary': """Custom Sale Exchange Rate for Orders and its Invoices and Payments""",
+    'description': """Custom Sale Exchange Rate for Orders and its Invoices and Payments""",
+    'author': "SUITEDOO",
+    'website': "https://www.suitedoo.com",
+    'category': "Sales/Sales",
+    'version': '0.1',
+    'depends': ['sale'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/inherit_sale_order.xml',
+        'views/inherit_account_move.xml',
+    ],
+    'installable': True,
+    'auto_install': False
+}

--- a/s_custom_sale_rate/i18n/es_MX.po
+++ b/s_custom_sale_rate/i18n/es_MX.po
@@ -1,0 +1,161 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* s_custom_sale_rate
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-14 20:02+0000\n"
+"PO-Revision-Date: 2023-07-14 20:02+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: s_custom_sale_rate
+#: model:ir.model.fields,help:s_custom_sale_rate.field_sale_order__foreign_currency
+msgid ""
+"Auxiliary field to handle the visualization of the elements of the view"
+msgstr ""
+"Campo auxiliar para manejar la visualización de los elementos de la vista"
+
+#. module: s_custom_sale_rate
+#: model:ir.model.fields,help:s_custom_sale_rate.field_account_bank_statement_line__sale_order_ids
+#: model:ir.model.fields,help:s_custom_sale_rate.field_account_move__sale_order_ids
+#: model:ir.model.fields,help:s_custom_sale_rate.field_account_payment__sale_order_ids
+msgid "Auxiliary field to link the sales orders with their payment"
+msgstr "Campo auxiliar para vincular las órdenes de venta con su pago"
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_account_move.py:0
+#, python-format
+msgid ""
+"Can not invoice multiple sales orders with manual exchange rate and "
+"automatic exchange rate together."
+msgstr ""
+"No se pueden facturar varios pedidos de venta con tipo de cambio manual y "
+"tipo de cambio automático juntos."
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_account_move.py:0
+#, python-format
+msgid "Can not invoice orders with different manual currency."
+msgstr "No se pueden facturar pedidos con moneda manual diferente."
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_account_move.py:0
+#, python-format
+msgid "Can not invoice orders with different manual exchange rate."
+msgstr "No se pueden facturar pedidos con diferente tipo de cambio manual."
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_account_move.py:0
+#, python-format
+msgid ""
+"Can not invoice orders with manual exchange rate in a different currency."
+msgstr ""
+"No se pueden facturar pedidos con tipo de cambio manual en una moneda "
+"diferente."
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_account_payment.py:0
+#, python-format
+msgid ""
+"Can not pay invoices with manual exchange rate and automatic exchange rate "
+"together."
+msgstr ""
+"No se pueden pagar facturas con tipo de cambio manual y tipo de cambio "
+"automático juntos."
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_account_payment.py:0
+#, python-format
+msgid "Can not pay manual rate invoices with different exchange rate."
+msgstr ""
+"No se pueden pagar facturas de tarifa manual con diferente tipo de cambio."
+
+#. module: s_custom_sale_rate
+#: model:ir.model,name:s_custom_sale_rate.model_res_currency
+#: model_terms:ir.ui.view,arch_db:s_custom_sale_rate.s_inherit_sale_order_view_form
+msgid "Currency"
+msgstr "Divisa"
+
+#. module: s_custom_sale_rate
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_account_move_line__inverse_currency_rate
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_sale_order__manual_rate
+msgid "Exchange Rate"
+msgstr "Tasa de cambio"
+
+#. module: s_custom_sale_rate
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_sale_order__foreign_currency
+msgid "Foreign Currency"
+msgstr "Moneda extranjera"
+
+#. module: s_custom_sale_rate
+#: model:ir.model,name:s_custom_sale_rate.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento contable"
+
+#. module: s_custom_sale_rate
+#: model:ir.model,name:s_custom_sale_rate.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: s_custom_sale_rate
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_sale_order__manual_currency_id
+msgid "Manual Currency"
+msgstr "Divisa manual"
+
+#. module: s_custom_sale_rate
+#: model:ir.model,name:s_custom_sale_rate.model_account_payment
+msgid "Payments"
+msgstr "Pagos"
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_account_payment.py:0
+#, python-format
+msgid ""
+"Payments for orders with a manual exchange rate cannot be made in a "
+"different currency."
+msgstr ""
+"Los pagos de pedidos con tipo de cambio manual no se pueden realizar en una "
+"moneda diferente."
+
+#. module: s_custom_sale_rate
+#: model:ir.model,name:s_custom_sale_rate.model_account_payment_register
+msgid "Register Payment"
+msgstr "Registrar pago"
+
+#. module: s_custom_sale_rate
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_account_bank_statement_line__sale_order_ids
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_account_move__sale_order_ids
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_account_payment__sale_order_ids
+msgid "Sale Order"
+msgstr "Orden de venta"
+
+#. module: s_custom_sale_rate
+#: model:ir.model,name:s_custom_sale_rate.model_sale_order
+msgid "Sales Order"
+msgstr "Orden de venta"
+
+#. module: s_custom_sale_rate
+#: model:ir.model.fields,field_description:s_custom_sale_rate.field_sale_order__use_manual_rate
+msgid "Set Exchange Rate"
+msgstr "Fijar tipo de cambio"
+
+#. module: s_custom_sale_rate
+#. odoo-python
+#: code:addons/s_custom_sale_rate/models/inherit_sale_order.py:0
+#, python-format
+msgid "You must specify exchange rate."
+msgstr "Debe especificar el tipo de cambio."

--- a/s_custom_sale_rate/models/__init__.py
+++ b/s_custom_sale_rate/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import inherit_sale_order
+from . import inherit_account_move
+from . import inherit_account_payment

--- a/s_custom_sale_rate/models/inherit_account_move.py
+++ b/s_custom_sale_rate/models/inherit_account_move.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, Command, _
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.constrains('currency_id', 'invoice_line_ids')
+    def _constrains_currency(self):
+        """
+        Realizar validaciones asociadas al tipo de cambio manual
+        """
+        self._check_manual_currency_rate()
+
+    def action_post(self):
+        """
+        Realizar validaciones asociadas al tipo de cambio manual
+        """
+        self._check_manual_currency_rate()
+        res = super().action_post()
+        return res
+
+    def _check_manual_currency_rate(self):
+        """
+        Si la venta que generó la factura usa tipo de cambio manual restringir la divisa a la de esta
+        """
+        for rec in self:
+            orders = rec.line_ids.sale_line_ids.order_id
+            mr_orders = orders.filtered(
+                lambda so: so.foreign_currency and so.use_manual_rate)
+
+            if len(mr_orders):
+                # Se valida que no se puedan asociar facturas a órdenes de venta con y sin tipo de cambio manual
+                if len(orders) != len(mr_orders):
+                    raise UserError(
+                        _('Can not invoice multiple sales orders with manual exchange rate and automatic exchange rate together.'))
+
+                # Se valida que no se pueda cambiar la moneda de la facturas asociadas a órdenes de venta con tipo de cambio manual
+                for so in mr_orders:
+                    if so.manual_currency_id.id != rec.currency_id.id:
+                        raise UserError(
+                            _('Can not invoice orders with manual exchange rate in a different currency.'))
+
+                # Se valida que no se puedan asociar facturas a múltiples órdenes de venta
+                # con diferente divisa manual o de la misma divisa manual con distintas tasas de cambio
+                if len(mr_orders) > 1:
+                    if len(mr_orders.manual_currency_id) == 1:
+                        if len(set(mr_orders.mapped('manual_rate'))) > 1:
+                            raise UserError(
+                                _('Can not invoice orders with different manual exchange rate.'))
+                    else:
+                        raise UserError(
+                            _('Can not invoice orders with different manual currency.'))
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    inverse_currency_rate = fields.Float(
+        compute='_compute_inverse_currency_rate', string='Exchange Rate')
+
+    @api.depends('currency_rate')
+    def _compute_inverse_currency_rate(self):
+        for line in self:
+            if not line.currency_rate:
+                line.inverse_currency_rate = 1.0
+            else:
+                line.inverse_currency_rate = 1.0 / line.currency_rate
+
+    def _compute_currency_rate(self):
+        """
+        Si la(s) orden(es) de venta usa tipo de cambio manual, usarlo para las líneas de la factura
+        """
+        res = super()._compute_currency_rate()
+
+        # En el caso de las facturas
+        mr_orders = self.sale_line_ids.order_id.filtered(
+            lambda so: so.foreign_currency and so.use_manual_rate)
+        if mr_orders:
+            currency_rate = 1.0/mr_orders[0].manual_rate
+            for line in self:
+                line.currency_rate = currency_rate
+        else:
+            for line in self:
+                # En el caso de asientos de base de efectivo
+                if line.move_id.tax_cash_basis_origin_move_id:
+                    mr_orders = line.move_id.tax_cash_basis_origin_move_id.line_ids.sale_line_ids.order_id.filtered(
+                        lambda so: so.foreign_currency and so.use_manual_rate)
+                    if mr_orders:
+                        currency_rate = 1.0/mr_orders[0].manual_rate
+                        line.currency_rate = currency_rate
+        return res
+
+    # TODO:Mantener por si fuese necesario, actualmente no se usa las
+    # facturas se agrupan por moneda y tasa de cambio manual
+    # @api.model_create_multi
+    # def create(self, vals_list):
+    #     """
+    #     Si existen órdenes con tipo de cambio manual y automático simultáneamente
+    #     o existen órdenes en la misma moneda con diferente tipo de cambio manual
+    #     se divide el impuesto por órdenes para evitar los descuadres introducidos
+    #     por el tipo de cambio
+    #     """
+    #     new_vals_list = []
+    #     for vals in vals_list:
+    #         keep_val = True
+    #         if vals.get('display_type', '') == 'tax' and vals.get('move_id', False):
+    #             move = self.env['account.move'].browse([vals['move_id']])
+    #             orders = move.invoice_line_ids.sale_line_ids.order_id
+    #             mr_orders = orders.filtered(
+    #                 lambda so: so.foreign_currency and so.use_manual_rate)
+    #             if len(mr_orders):
+    #                 rates_by_currency = {}
+    #                 for mr_order in mr_orders:
+    #                     rates_by_currency.setdefault(
+    #                         mr_order.manual_currency_id.id, [])
+    #                     if mr_order.manual_rate not in rates_by_currency[mr_order.manual_currency_id.id]:
+    #                         rates_by_currency[mr_order.manual_currency_id.id].append(
+    #                             mr_order.manual_rate)
+    #                 if len(orders) != len(mr_orders) or len(mr_orders) > 1 and any([len(rates) > 1 for rates in rates_by_currency.values()]):
+    #                     # Si existen órdenes con tipo de cambio manual y automático simultáneamente
+    #                     # o existen órdenes en la misma moneda con diferente tipo de cambio manual
+    #                     # dividir el impuesto por órdenes
+    #                     keep_val = False
+    #                     for order in orders:
+    #                         new_val = vals.copy()
+    #                         tax_base_amount = order.amount_untaxed
+    #                         amount_currency = order.amount_tax
+    #                         balance = order.amount_tax
+    #                         if order.foreign_currency and order.use_manual_rate:
+    #                             tax_base_amount = order.company_id.currency_id.round(
+    #                                 order.amount_untaxed * order.manual_rate)
+    #                             balance = order.company_id.currency_id.round(
+    #                                 order.amount_tax * order.manual_rate)
+    #                         new_val.update({
+    #                             'currency_id': move.currency_id.id,
+    #                             'tax_base_amount': tax_base_amount if vals['amount_currency'] > 0 else -tax_base_amount,
+    #                             'amount_currency': amount_currency if vals['balance'] > 0 else -amount_currency,
+    #                             'balance': balance if vals['balance'] > 0 else -balance,
+    #                             'name': ' '.join([vals['name'], '-', order.name]),
+    #                             'sale_line_ids': [Command.set(order.order_line.ids)]
+    #                         })
+    #                         new_vals_list.append(new_val)
+    #         if keep_val:
+    #             new_vals_list.append(vals)
+    #     return super().create(new_vals_list)

--- a/s_custom_sale_rate/models/inherit_account_payment.py
+++ b/s_custom_sale_rate/models/inherit_account_payment.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+
+from odoo import Command, _, api, fields, models
+from odoo.addons.sale.models.sale_order import READONLY_FIELD_STATES
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    sale_order_ids = fields.Many2many(
+        'sale.order',
+        string='Sale Order',
+        help="Auxiliary field to link the sales orders with their payment"
+    )
+
+
+class AccountPayment(models.Model):
+    _inherit = 'account.payment'
+
+    def _prepare_move_line_default_vals(self, write_off_line_vals=None):
+        """
+        Si el pago es para órdenes con tipo de cambio manual usarlo para los pauntes contables
+        """
+        res = super()._prepare_move_line_default_vals(write_off_line_vals)
+
+        mr_orders = self.sale_order_ids.filtered(
+            lambda so: so.foreign_currency and so.use_manual_rate)
+        if len(mr_orders) > 0:
+            manual_rate = mr_orders[0].manual_rate
+            for line_vals in res:
+                custom_amount = self.currency_id.round(
+                    self.amount*manual_rate)
+                if line_vals['debit'] != 0:
+                    if line_vals['debit'] < 0:
+                        custom_amount = -custom_amount
+                    line_vals['debit'] = custom_amount
+                else:
+                    if line_vals['credit'] < 0:
+                        custom_amount = -custom_amount
+                    line_vals['credit'] = custom_amount
+
+        return res
+
+    @api.constrains('currency_id')
+    def _constrains_payment_currency(self):
+        """
+        Si el pago es de órdenes con tasa de cambio manual 
+        no se puede usar una moneda distinta a la de la orden
+
+        Evitar que se paguen facturas con tipo de cambio manual con diferente tasa de cambio 
+        o facturas con tasa de cambio manual y automática simultáneamente
+        """
+        for payment in self.filtered(lambda x: x.payment_type == 'inbound'):
+            orders = payment.sale_order_ids
+            mr_orders = orders.filtered(
+                lambda so: so.foreign_currency and so.use_manual_rate)
+            if len(mr_orders) > 0:
+                if len(mr_orders) != len(orders):
+                    raise UserError(
+                        _('Can not pay invoices with manual exchange rate and automatic exchange rate together.'))
+                if payment.currency_id.id != mr_orders[0].manual_currency_id.id:
+                    raise UserError(
+                        _('Payments for orders with a manual exchange rate cannot be made in a different currency.'))
+                if len(set([(so.manual_currency_id.id, so.manual_rate) for so in mr_orders])) > 1:
+                    raise UserError(
+                        _("Can not pay manual rate invoices with different exchange rate."))
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = 'account.payment.register'
+
+    def _create_payments(self):
+        """
+        Validar que se puedan crear los pagos para las facturas selecionadas
+        """
+        return super()._create_payments()
+
+    def _create_payment_vals_from_wizard(self, batch_result):
+        """
+        Si el pago se realiza para facturas generadas a partir de órdenes con tipo de cambio manual
+        se establecen en el pago para tener forma de determinar luego que el  es para esas órdenes 
+        """
+        res = super()._create_payment_vals_from_batch(batch_result)
+        if batch_result['lines']:
+            invoices = batch_result['lines'].move_id
+            mr_orders = invoices.invoice_line_ids.sale_line_ids.order_id.filtered(
+                lambda so: so.foreign_currency and so.use_manual_rate)
+            if len(mr_orders) > 0:
+                res.update({
+                    'sale_order_ids': [Command.set(mr_orders.ids)]
+                })
+        return res
+
+    def _create_payment_vals_from_batch(self, batch_result):
+        """
+        Si el pago se realiza para facturas generadas a partir de órdenes con tipo de cambio manual
+        se establecen en el pago para tener forma de determinar luego que el pago es para esas órdenes 
+        """
+        res = super()._create_payment_vals_from_batch(batch_result)
+        if batch_result['lines']:
+            invoices = batch_result['lines'].move_id
+            mr_orders = invoices.invoice_line_ids.sale_line_ids.order_id.filtered(
+                lambda so: so.foreign_currency and so.use_manual_rate)
+            if len(mr_orders) > 0:
+                res.update({
+                    'sale_order_ids': [Command.set(mr_orders.ids)]
+                })
+        return res
+
+    def _get_line_batch_key(self, line):
+        """
+        Si la línea pertenece a una factura generada a partir de una ordern con tasa de cambio manual
+        Usar la modeda de la factura (la misma de la orden)
+        """
+        res = super()._get_line_batch_key(line)
+        mr_orders = line.move_id.invoice_line_ids.sale_line_ids.order_id.filtered(
+            lambda so: so.foreign_currency and so.use_manual_rate)
+        if len(mr_orders):
+            res['currency_id'] = line.move_id.currency_id.id
+        return res
+
+    def _compute_from_lines(self):
+        """
+        Si el pago es para facturas que se generaron a partir de órdenes de venta con tasa 
+        de cambio manual deshabilitar la edición para que no se cambie la moneda
+        """
+        res = super()._compute_from_lines()
+        for wizard in self:
+            if wizard.line_ids._origin.move_id.invoice_line_ids.sale_line_ids.order_id.filtered(
+                    lambda so: so.foreign_currency and so.use_manual_rate):
+                wizard.can_edit_wizard = False
+        return res
+
+
+class ResCurrency(models.Model):
+    _inherit = 'res.currency'
+
+    @api.model
+    def _get_convxersion_rate(self, from_currency, to_currency, company, date):
+        """
+        Si la tasa de cambio fue establecida desde el asistente para registrar el pago, usar esta
+        """
+        if 'manual_payment_rate' in self.env.context and self.env.context['manual_payment_rate']:
+            return self.env.context['manual_payment_rate']
+        return super()._get_conversion_rate(from_currency, to_currency, company, date)
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _compute_currency_rate(self):
+        """
+        Si la orden de venta usa tipo de cambio manual, usarlo para las líneas del pago
+        """
+        res = super()._compute_currency_rate()
+        for line in self:
+            mr_orders = line.move_id.sale_order_ids.filtered(
+                lambda so: so.foreign_currency and so.use_manual_rate)
+            if mr_orders:
+                currency_rate = 1.0/mr_orders[0].manual_rate
+                line.currency_rate = currency_rate
+        return res

--- a/s_custom_sale_rate/models/inherit_sale_order.py
+++ b/s_custom_sale_rate/models/inherit_sale_order.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+from odoo.addons.sale.models.sale_order import READONLY_FIELD_STATES
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    foreign_currency = fields.Boolean(
+        compute='_compute_foreign_currency',
+        string='Foreign Currency',
+        help='Auxiliary field to handle the visualization of the elements of the view'
+    )
+
+    use_manual_rate = fields.Boolean(
+        'Set Exchange Rate',
+        default=False,
+        states=READONLY_FIELD_STATES)
+    manual_currency_id = fields.Many2one(
+        'res.currency',
+        default=False,
+        string='Manual Currency',
+        states=READONLY_FIELD_STATES
+    )
+    manual_rate = fields.Float(
+        'Exchange Rate',
+        default=0,
+        states=READONLY_FIELD_STATES
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        return super().create(vals_list)
+
+    @api.onchange('pricelist_id')
+    def _onchange_pricelist_id_update_manual_currency_id(self):
+        """
+        Establecer por defecto la divisa de la lista de precios
+        """
+        for rec in self:
+            rec.manual_currency_id = rec.pricelist_id.currency_id or rec.env.company.currency_id
+
+    @api.depends('company_id', 'manual_currency_id')
+    def _compute_foreign_currency(self):
+        """
+        Campo auxiliar para usar en los dominios en la vista si la divisa no es la de la compañía
+        """
+        for rec in self:
+            rec.foreign_currency = rec.company_id.currency_id.id != rec.manual_currency_id.id
+
+    def _prepare_invoice(self):
+        """
+        Si la moneda es diferente a la moneda de la compañía y está indicado que se va a utilizar
+        tipo de cambio manual, crear la factura en la moneda indicada
+        """
+        res = super()._prepare_invoice()
+        if self.foreign_currency and self.manual_currency_id:
+            res.update({
+                'currency_id': self.manual_currency_id.id,
+                'manual_rate': self.manual_rate
+            })
+        return res
+
+    @api.constrains('foreign_currency', 'manual_currency_id', 'use_manual_rate', 'manual_rate')
+    def _constrains_manual_currency_rate(self):
+        """
+        Garantizar la consistencia de los datos
+        """
+        for rec in self:
+            if rec.foreign_currency and rec.use_manual_rate and rec.manual_rate <= 0:
+                # Si la moneda es diferente a la moneda de la compañía y está indicado que
+                # se va a utilizar tipo de cambio manual, validar que este se mayor que cero
+                raise UserError(_('You must specify exchange rate.'))
+
+            # Garantizar la consistencia de los datos para agrupar
+            # las facturas por moneda manual y tasa de cambio manual
+            # Se valida que el valor del parámetro que se quiere
+            # modificar sea distinto al valor que se quiere establecer
+            # para evitar error de recursion depth
+            vals = {}
+            if not rec.foreign_currency and rec.use_manual_rate != False:
+                vals.update({'use_manual_rate': False})
+            if not rec.use_manual_rate and rec.manual_rate != 0:
+                vals.update({'manual_rate': 0})
+            if vals:
+                rec.write(vals)
+
+    def _get_invoice_grouping_keys(self):
+        """
+        Agrupar las facturas por la divisa y la tasa de cambio para evitar inconsistencias
+        en los datos introducidas por el tipo de cambio entre los diferentes tipos de tasa 
+        de cambio manuales de las facturas en la misma moneda
+        original: 
+            ['company_id', 'partner_id', 'currency_id']
+        se extiende 'currency_id':
+            ['currency_id', 'manual_rate']
+        """
+        res = super()._get_invoice_grouping_keys()
+        if self.filtered(lambda x: x.foreign_currency and x.use_manual_rate):
+            res.extend(['manual_rate'])
+        return res
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Remover claves temporales usadas para agrupar las 
+        facturas por divisa y tasa de cambio manual
+        """
+        for vals in vals_list:
+            if 'manual_rate' in vals:
+                vals.pop('manual_rate')
+        return super().create(vals_list)

--- a/s_custom_sale_rate/security/ir.model.access.csv
+++ b/s_custom_sale_rate/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/s_custom_sale_rate/views/inherit_account_move.xml
+++ b/s_custom_sale_rate/views/inherit_account_move.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_view_move_form" model="ir.ui.view">
+            <field name="name">s.inherit.view.move.form</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='line_ids']/tree/field[@name='amount_currency']"
+                    position="after">
+                    <field name="inverse_currency_rate" groups="base.group_multi_currency" optional="hide" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/s_custom_sale_rate/views/inherit_sale_order.xml
+++ b/s_custom_sale_rate/views/inherit_sale_order.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_sale_order_view_form" model="ir.ui.view">
+            <field name="name">s.inherit.sale.order.view.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='order_details']" position="inside">
+                    <field name="foreign_currency" invisible="1" />
+                    <field name="manual_currency_id" string="Currency" />
+                    <field name="use_manual_rate"
+                        attrs="{'invisible': [('foreign_currency', '!=', True)] }" />
+                    <field name="manual_rate"
+                        attrs="{'invisible': ['|', ('foreign_currency', '!=', True), ('use_manual_rate', '!=', True) ]}" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Adicionar divisa y tipo de cambio manual a la orden de venta, validaciiones. Generar facturas a parir de la orden de venta utilzando la divisa y tasa de cambio de esta. Sobrescribir método que calcula la tasa de cambio para usar la tasa de cambio manual de la orden en los apuntes contables de la factura, del pago y de los asientos en base de efectivo. Validar que no se pueda cambiar la moneda de la factura por una distinta a la de la orden si tiene tasa de cambio manual Generar facturas agrupadas por divisa y tasa de cambio cuando se generan desde el asistente en el listado de órdenes Validaciones por si la factura se crea desde el código por otra vía: En una misma factura no se pueden incluir órdenes de diferente moneda, o de la misma moneda con tipo de cambio manual o con y sin tipo de cambio manual simultáneamente. Generar pagos para facturas de órdenes con tipo de cambio manual usando la modeda y la tasa de cambio de la orden. Validar que no se pueda cambiar la moneda de un pago de una orden con tipo de cambio manual. Sobrescribir método que calcula la tasa de cambio para las líneas del pago. Cuando el pago se genera desde el asistente para varias facturas crear uno para cada una para evitar inconsistencias por el tipo de cambio, TODO: esto se puede mejorar agrupando los pagos para las facturas de una misma moneda y tasa de cambio, similar a lo que se hizo con las facturas para las órdenes. Validaciones por si el pago se genera via código: si las facturas son de órdenes con tipo de cambio manual a un mismo pago no se puedan asociar facturas de diferente moneda o en la misma moneda con diferente tipo de cambio o facturas con y sin tipo de cambio manual