### PR TITLE
PROD: Facturación Proveedores – Conexión con SAT

### DIFF
--- a/s_l10n_mx_edi_suppliers/__init__.py
+++ b/s_l10n_mx_edi_suppliers/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/s_l10n_mx_edi_suppliers/__manifest__.py
+++ b/s_l10n_mx_edi_suppliers/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "EDI for Mexico suppliers features",
+    'summary': """Electronic invoice suppliers features""",
+    'description': """
+       Electronic invoice suppliers features.
+    """,
+    'author': "SUITEDOO",
+    'website': "https://www.suitedoo.com",
+    'category': 'Accounting/Localizations/EDI',
+    'version': '0.1',
+    'depends': ['l10n_mx_edi'],
+    'data': [
+        'data/ir_cron.xml',
+        'views/inherit_account_move.xml',
+        'views/inherit_res_config_settings.xml',
+    ],
+    'installable': True,
+    'auto_install': False
+}

--- a/s_l10n_mx_edi_suppliers/data/ir_cron.xml
+++ b/s_l10n_mx_edi_suppliers/data/ir_cron.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<odoo>
+    <data noupdate="0">
+        <record id="ir_cron_update_pac_status_vendor_invoice" model="ir.cron">
+            <field name="name">Automatic update of state on the SAT (for suppliers invoices)</field>
+            <field name="model_id" ref="account.model_account_move" />
+            <field name="state">code</field>
+            <field name="code">env['account.move']._l10n_mx_edi_cron_update_vendor_sat_status()</field>
+            <field name="user_id" ref="base.user_admin" />
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False" />
+            <field name="nextcall"
+                eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 22:00:00')" />
+        </record>
+    </data>
+</odoo>

--- a/s_l10n_mx_edi_suppliers/i18n/es_MX.po
+++ b/s_l10n_mx_edi_suppliers/i18n/es_MX.po
@@ -1,0 +1,152 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* s_l10n_mx_edi_suppliers
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-21 04:38+0000\n"
+"PO-Revision-Date: 2023-07-21 04:38+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_view_move_form
+msgid "<i title=\"Check\" role=\"img\" aria-label=\"Check\" class=\"fa fa-refresh\"/> Check"
+msgstr ""
+"<i title=\"Verificar\" role=\"img\" aria-label=\"Verificar\" class=\"fa fa-"
+"refresh\"/> Verificar"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.actions.server,name:s_l10n_mx_edi_suppliers.ir_cron_update_pac_status_vendor_invoice_ir_actions_server
+#: model:ir.cron,cron_name:s_l10n_mx_edi_suppliers.ir_cron_update_pac_status_vendor_invoice
+msgid "Automatic update of state on the SAT (for suppliers invoices)"
+msgstr ""
+"Actualización automática de estado en el SAT (para facturas de proveedores)"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_vendor_sat_status__cancelled
+msgid "Cancelled"
+msgstr "Cancelado"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model,name:s_l10n_mx_edi_suppliers.model_res_company
+msgid "Companies"
+msgstr "Empresas"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model,name:s_l10n_mx_edi_suppliers.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ajustes de configuración"
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_account_move.py:0
+#, python-format
+msgid "Failure during update of the SAT status: %(msg)s"
+msgstr "Falla durante la actualización del estado del SAT: %(msg)s"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_view_move_form
+msgid "Fiscal Folio"
+msgstr "Folio fiscal"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_vendor_cfdi_uuid
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_vendor_cfdi_uuid
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_vendor_cfdi_uuid
+msgid "Folio in electronic invoice, is returned by SAT when send to stamp."
+msgstr ""
+"Folio en factura electrónica, es devuelto por el SAT al enviar a timbre."
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model,name:s_l10n_mx_edi_suppliers.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento contable"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_vendor_sat_status__not_found
+msgid "Not Found"
+msgstr "No encontrado"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_vendor_sat_status__undefined
+msgid "Not Synced Yet"
+msgstr "No sincronizado todavía"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_vendor_cfdi_uuid
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_vendor_cfdi_uuid
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_vendor_cfdi_uuid
+msgid "Providers Fiscal Folio"
+msgstr "Folio fiscal"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_vendor_sat_status
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_vendor_sat_status
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_vendor_sat_status
+msgid "Refers to the status of the journal entry inside the SAT system."
+msgstr ""
+"Se refiere al estado del asiento de diario dentro del sistema del SAT."
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_vendor_sat_status
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_vendor_sat_status
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_vendor_sat_status
+msgid "SAT status"
+msgstr "Estado SAT"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_vendor_sat_status__none
+msgid "State not defined"
+msgstr "Estado no definido"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_vendor_status_change_date
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_vendor_status_change_date
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_vendor_status_change_date
+msgid "Status change date"
+msgstr "Fecha de cambio de estado"
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_account_move.py:0
+#, python-format
+msgid "Status for this invoice change in SAT from \"%s\" to \"%s\""
+msgstr "El estado de esta factura cambió en SAT de \"%s\" a \"%s\""
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_res_company__vendor_bills_status_notification_user_ids
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_res_config_settings__vendor_bills_status_notification_user_ids
+msgid "Users to notify"
+msgstr "Usuarios a notificar"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_res_company__vendor_bills_status_notification_user_ids
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_res_config_settings__vendor_bills_status_notification_user_ids
+#: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_res_config_settings_view_form
+msgid ""
+"Users to notify when the status of supplier invoices changes in the SAT"
+msgstr ""
+"Usuarios a notificar cuando cambia el estado de las facturas de proveedores "
+"en el SAT"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_vendor_sat_status__valid
+msgid "Valid"
+msgstr "Válido"
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_res_config_settings.py:0
+#, python-format
+msgid ""
+"You must specify at least 2 users to notify when vendors bill state change"
+msgstr ""
+"Debe especificar al menos 2 usuarios para notificar cuando cambie el estado "
+"de las facturas de proveedor en el SAT"

--- a/s_l10n_mx_edi_suppliers/models/__init__.py
+++ b/s_l10n_mx_edi_suppliers/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import inherit_account_move
+from . import inherit_res_config_settings

--- a/s_l10n_mx_edi_suppliers/models/inherit_account_move.py
+++ b/s_l10n_mx_edi_suppliers/models/inherit_account_move.py
@@ -1,0 +1,143 @@
+from odoo import fields, models, api, _, registry
+from odoo.tools import float_repr
+import threading
+from odoo.api import Environment
+import odoo
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    l10n_mx_edi_vendor_cfdi_uuid = fields.Char(
+        string='Providers Fiscal Folio',
+        copy=False,
+        default='',
+        help='Folio in electronic invoice, is returned by SAT when send to stamp.',
+    )
+    l10n_mx_edi_vendor_status_change_date = fields.Date(
+        'Status change date'
+    )
+    l10n_mx_edi_vendor_sat_status = fields.Selection(
+        selection=[
+            ('none', "State not defined"),
+            ('undefined', "Not Synced Yet"),
+            ('not_found', "Not Found"),
+            ('cancelled', "Cancelled"),
+            ('valid', "Valid"),
+        ],
+        string="SAT status",
+        readonly=True,
+        copy=False,
+        required=True,
+        tracking=True,
+        default='undefined',
+        help="Refers to the status of the journal entry inside the SAT system.")
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Si se establece el uuid el estado SAT en no definido
+        hasta tanto no se verifique contra el SAT
+        """
+        for vals in vals_list:
+            if 'l10n_mx_edi_vendor_cfdi_uuid' in vals and vals.get('l10n_mx_edi_vendor_cfdi_uuid', False):
+                vals.update({
+                    'l10n_mx_edi_vendor_sat_status': 'undefined',
+                    'l10n_mx_edi_vendor_status_change_date': False,
+                })
+        return super().create(vals)
+
+    def write(self, vals):
+        """
+        Si se establece el uuid el estado SAT en no definido
+        hasta tanto no se verifique contra el SAT
+        """
+        if 'l10n_mx_edi_vendor_cfdi_uuid' in vals and vals.get('l10n_mx_edi_vendor_cfdi_uuid', False):
+            vals.update({
+                'l10n_mx_edi_vendor_sat_status': 'undefined',
+                'l10n_mx_edi_vendor_status_change_date': False,
+            })
+        return super().write(vals)
+
+    def action_update_vendor_sat_status(self):
+        self.ensure_one()
+        self.l10n_mx_edi_update_vendor_sat_status()
+
+    def l10n_mx_edi_update_vendor_sat_status_notified(self):
+        """
+        Método auxiliar para ejecutar el que actualiza el estado del SAT
+        pasando los usurios configurados a los que se debe notificar
+        """
+        users_to_notify = self.env.company.vendor_bills_status_notification_user_ids
+        if not users_to_notify:
+            users_to_notify = self.env.ref('base.user_admin')
+        self.l10n_mx_edi_update_vendor_sat_status(
+            users_to_notify=users_to_notify)
+
+    def l10n_mx_edi_update_vendor_sat_status(self, users_to_notify=None):
+        '''
+        Validar que los uuids de las facturas de proveedores son válidos.
+        Si cambia de estado y se indican usuarios, notificarlos
+        '''
+
+        for move in self:
+            supplier_rfc = move.l10n_mx_edi_cfdi_supplier_rfc
+            customer_rfc = move.l10n_mx_edi_cfdi_customer_rfc
+            total = float_repr(move.l10n_mx_edi_cfdi_amount,
+                               precision_digits=move.currency_id.decimal_places)
+            uuid = move.l10n_mx_edi_cfdi_uuid
+
+            try:
+                status = self.env['account.edi.format']._l10n_mx_edi_get_sat_status(
+                    supplier_rfc, customer_rfc, total, uuid)
+            except Exception as e:
+                move.message_post(
+                    body=_("Failure during update of the SAT status: %(msg)s", msg=str(e)))
+                continue
+
+            new_status = ''
+            if status == 'Vigente':
+                new_status = 'valid'
+            elif status == 'Cancelado':
+                new_status = 'cancelled'
+            elif status == 'No Encontrado':
+                new_status = 'not_found'
+            else:
+                new_status = 'none'
+
+            old_status = move.l10n_mx_edi_vendor_sat_status
+            if new_status != old_status:
+                move.l10n_mx_edi_vendor_sat_status = new_status
+                move.l10n_mx_edi_vendor_status_change_date = fields.Date.today()
+
+                if old_status == 'undefined' and new_status == 'valid':
+                    # Si el estdo aún no se ha verificado y al
+                    # hacerlo resulta que este es válido no notificar
+                    continue
+                elif users_to_notify:
+                    description_selection_dict = dict(
+                        self.env['account.move']._fields['l10n_mx_edi_vendor_sat_status']._description_selection(self.with_context(lang=self.env.user.lang).env))
+                    for user in users_to_notify:
+                        move.activity_schedule(
+                            'mail.mail_activity_data_todo',
+                            fields.Date.today(),
+                            note=_('Status for this invoice change in SAT from "%s" to "%s"') % (
+                                _(description_selection_dict[old_status]),
+                                _(description_selection_dict[new_status])
+                            ),
+                            user_id=user.id)
+
+    @ api.model
+    def _l10n_mx_edi_cron_update_vendor_sat_status(self):
+        '''
+        Validar que los uuids de las facturas de proveedores con válidos.
+        TODO: la validación se va a hacer para todas las facturas de proveedores
+        que tienen el uuid establecido el el caso de muchas facturas esto puede afectar
+        el rendimiento, buscar alguna forma de optimizarlo
+        '''
+        to_process = self.env['account.move'].search([
+            ('l10n_mx_edi_vendor_cfdi_uuid', '!=', ''),
+            ('move_type', '=', 'in_invoice')
+        ])
+        for move in to_process:
+            move.l10n_mx_edi_update_vendor_sat_status_notified()

--- a/s_l10n_mx_edi_suppliers/models/inherit_res_config_settings.py
+++ b/s_l10n_mx_edi_suppliers/models/inherit_res_config_settings.py
@@ -1,0 +1,36 @@
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    vendor_bills_status_notification_user_ids = fields.Many2many(
+        'res.users',
+        'res_company_vendor_bills_status_user_rel',
+        'company_id',
+        'user_id',
+        string='Users to notify',
+        help='Users to notify when the status of supplier invoices changes in the SAT'
+    )
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    vendor_bills_status_notification_user_ids = fields.Many2many(
+        related='company_id.vendor_bills_status_notification_user_ids',
+        readonly=False
+    )
+
+    @api.constrains('vendor_bills_status_notification_user_ids')
+    def _contrains_vendor_bills_notification_users(self):
+        """
+        Cuando se modifican los usuarios a ser notificados desde
+        la configuración de contabilidad validar que sean 2 o mas.
+        """
+        if self.env.context.get('module', '') == 'account' and self.vendor_bills_status_notification_user_ids:
+            if len(self.vendor_bills_status_notification_user_ids) < 2:
+                raise ValidationError(
+                    _('You must specify at least 2 users to notify when vendors bill state change')
+                )

--- a/s_l10n_mx_edi_suppliers/security/ir.model.access.csv
+++ b/s_l10n_mx_edi_suppliers/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/s_l10n_mx_edi_suppliers/views/inherit_account_move.xml
+++ b/s_l10n_mx_edi_suppliers/views/inherit_account_move.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_view_move_form" model="ir.ui.view">
+            <field name="name">s.inherit.account.move.view.form</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='payment_reference']" position="after">
+                    <field name="l10n_mx_edi_vendor_cfdi_uuid"
+                        string="Fiscal Folio"
+                        attrs="{'invisible': [('move_type', '!=', 'in_invoice')] }" />
+
+                    <label for="l10n_mx_edi_vendor_sat_status"
+                        attrs="{'invisible': [('l10n_mx_edi_vendor_cfdi_uuid', 'in', [False, None, ''] )] }" />
+                    <div class="o_row"
+                        attrs="{'invisible': [('l10n_mx_edi_vendor_cfdi_uuid', 'in', [False, None, ''] )] }">
+                        <field name="l10n_mx_edi_vendor_sat_status" />
+
+
+                        <button name="action_update_vendor_sat_status" type="object"
+                            string="" class="oe_link"
+                            attrs="{'invisible': [('l10n_mx_edi_vendor_sat_status', '!=', 'undefined')]}">
+                            <i title="Check" role="img" aria-label="Check"
+                                class="fa fa-refresh" /> Check </button>
+                    </div>
+
+
+                    <field name="l10n_mx_edi_vendor_status_change_date"
+                        readonly="1"
+                        attrs="{'invisible': [('l10n_mx_edi_vendor_cfdi_uuid', 'in', [False, None, ''] )] }" />
+
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/s_l10n_mx_edi_suppliers/views/inherit_res_config_settings.xml
+++ b/s_l10n_mx_edi_suppliers/views/inherit_res_config_settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">s.inherit.res.config.settings.view.form</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="account.res_config_settings_view_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//div[@id='account_vendor_bills']" position="inside">
+                    <div class="col-xs-12 col-md-6 o_setting_box"
+                        id="vendor_bills_status_notification_user_ids">
+                        <label for="vendor_bills_status_notification_user_ids"
+                            string="Users to notify when the status of supplier invoices changes in the SAT" />
+                        <field
+                            name="vendor_bills_status_notification_user_ids"
+                            context="{'account_config': True}"
+                            options="{'no_create':true,'no_open':true}">
+                            <tree>
+                                <field name="name" />
+                                <field name="login" />
+                            </tree>
+                        </field>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Adicionar campos para información del estado de las facturas de proveedores en el SAT Funcionalidad para verificar el estado de las facturas de proveedores en el SAT a partir del folio fiscal Tarea programada que verifica el estado de las facturas de proveedores en el SAT y notifica a los usuarios en caso de que no se sea válida Configuración para especificar los usuarios que se deben notificar en caso de que la factura no sea válida Botón para chequear de forma manual el estado de la facturas en el SAT cuando se establece el Folio fiscal