### PR TITLE
TEST:  Facturación - Validación SAT

### DIFF
--- a/s_l10n_mx_edi_suppliers/__manifest__.py
+++ b/s_l10n_mx_edi_suppliers/__manifest__.py
@@ -14,6 +14,7 @@
         'data/ir_cron.xml',
         'views/inherit_account_move.xml',
         'views/inherit_res_config_settings.xml',
+        'views/inherit_hr_expense.xml',
     ],
     'installable': True,
     'auto_install': False

--- a/s_l10n_mx_edi_suppliers/i18n/es_MX.po
+++ b/s_l10n_mx_edi_suppliers/i18n/es_MX.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-21 04:38+0000\n"
-"PO-Revision-Date: 2023-07-21 04:38+0000\n"
+"POT-Creation-Date: 2023-07-28 18:02+0000\n"
+"PO-Revision-Date: 2023-07-28 18:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,6 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: s_l10n_mx_edi_suppliers
+#: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_hr_expense_view_form
 #: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_view_move_form
 msgid "<i title=\"Check\" role=\"img\" aria-label=\"Check\" class=\"fa fa-refresh\"/> Check"
 msgstr ""
@@ -30,11 +31,6 @@ msgstr ""
 "Actualización automática de estado en el SAT (para facturas de proveedores)"
 
 #. module: s_l10n_mx_edi_suppliers
-#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_sat_status_supplier__cancelled
-msgid "Cancelled"
-msgstr "Cancelado"
-
-#. module: s_l10n_mx_edi_suppliers
 #: model:ir.model,name:s_l10n_mx_edi_suppliers.model_res_company
 msgid "Companies"
 msgstr "Empresas"
@@ -45,14 +41,28 @@ msgid "Config Settings"
 msgstr "Ajustes de configuración"
 
 #. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_cfdi_customer_rfc
+msgid "Customer RFC"
+msgstr "RFC del cliente"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model,name:s_l10n_mx_edi_suppliers.model_hr_expense
+msgid "Expense"
+msgstr "Gasto"
+
+#. module: s_l10n_mx_edi_suppliers
 #. odoo-python
 #: code:addons/s_l10n_mx_edi_suppliers/models/inherit_account_move.py:0
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_account_move.py:0
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_hr_expense.py:0
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_hr_expense.py:0
+#: code:addons/s_l10n_mx_edi_suppliers/models/uuid_verification_tools.py:0
 #, python-format
 msgid "Failure during update of the SAT status: %(msg)s"
 msgstr "Falla durante la actualización del estado del SAT: %(msg)s"
 
 #. module: s_l10n_mx_edi_suppliers
-#: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_view_move_form
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_cfdi_uuid
 msgid "Fiscal Folio"
 msgstr "Folio fiscal"
 
@@ -60,9 +70,51 @@ msgstr "Folio fiscal"
 #: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_cfdi_uuid_supplier
 #: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_cfdi_uuid_supplier
 #: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_cfdi_uuid_supplier
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_cfdi_uuid
 msgid "Folio in electronic invoice, is returned by SAT when send to stamp."
 msgstr ""
 "Folio en factura electrónica, es devuelto por el SAT al enviar a timbre."
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__has_cfdi
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_move__has_cfdi
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_payment__has_cfdi
+msgid "Has Cfdi"
+msgstr "Posee cfdi"
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_account_move.py:0
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_hr_expense.py:0
+#, python-format
+msgid "Invoice SAT status is: \"%(msg)s\""
+msgstr "El estado de la factura en el SAT es: \"%(msg)s\""
+
+#. module: s_l10n_mx_edi_suppliers
+#: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_hr_expense_view_form
+#: model_terms:ir.ui.view,arch_db:s_l10n_mx_edi_suppliers.s_inherit_view_move_form
+msgid "Invoice UUID"
+msgstr "UUID factura"
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/uuid_verification_tools.py:0
+#, python-format
+msgid "Invoice UUID already registered"
+msgstr "El UUID de la factura ya ha sido registrado"
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/uuid_verification_tools.py:0
+#, python-format
+msgid ""
+"Invoice UUID structure is invalid, must contain uppercase letters A through "
+"F and numbers 0 through 9 in the format "
+"\"12A3BCD-4EFA-56B7-C891-23D4E56F7ABC\""
+msgstr ""
+"La estructura del UUID de la factura es inválida, debe contener letras "
+"mayúsculas de la A a la F y números de 0 a 9 en el formato "
+"\"12A3BCD-4EFA-56B7-C891-23D4E56F7ABC\""
 
 #. module: s_l10n_mx_edi_suppliers
 #: model:ir.model,name:s_l10n_mx_edi_suppliers.model_account_move
@@ -70,21 +122,11 @@ msgid "Journal Entry"
 msgstr "Asiento contable"
 
 #. module: s_l10n_mx_edi_suppliers
-#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_sat_status_supplier__not_found
-msgid "Not Found"
-msgstr "No encontrado"
-
-#. module: s_l10n_mx_edi_suppliers
-#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_sat_status_supplier__undefined
-msgid "Not Synced Yet"
-msgstr "No sincronizado todavía"
-
-#. module: s_l10n_mx_edi_suppliers
 #: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_cfdi_uuid_supplier
 #: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_cfdi_uuid_supplier
 #: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_cfdi_uuid_supplier
-msgid "Providers Fiscal Folio"
-msgstr "Folio fiscal"
+msgid "Providers Auxiliar Fiscal Folio"
+msgstr "Folio fiscal auxiliar del proveedor"
 
 #. module: s_l10n_mx_edi_suppliers
 #: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_sat_status_supplier
@@ -102,16 +144,25 @@ msgid "SAT status"
 msgstr "Estado SAT"
 
 #. module: s_l10n_mx_edi_suppliers
-#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_sat_status_supplier__none
-msgid "State not defined"
-msgstr "Estado no definido"
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_sat_status
+msgid "Sat status"
+msgstr "Estado SAT"
 
 #. module: s_l10n_mx_edi_suppliers
 #: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_bank_statement_line__l10n_mx_edi_status_change_date_supplier
 #: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_move__l10n_mx_edi_status_change_date_supplier
 #: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_account_payment__l10n_mx_edi_status_change_date_supplier
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_status_change_date
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_status_change_date_supplier
 msgid "Status change date"
 msgstr "Fecha de cambio de estado"
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_hr_expense.py:0
+#, python-format
+msgid "Status for the invoice change from \"%s\" to \"%s\""
+msgstr "El estado de la factura cambió de \"%s\" a \"%s\""
 
 #. module: s_l10n_mx_edi_suppliers
 #. odoo-python
@@ -119,6 +170,33 @@ msgstr "Fecha de cambio de estado"
 #, python-format
 msgid "Status for this invoice change in SAT from \"%s\" to \"%s\""
 msgstr "El estado de esta factura cambió en SAT de \"%s\" a \"%s\""
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_cfdi_supplier_rfc
+msgid "Supplier RFC"
+msgstr "RFC del proveedor"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_cfdi_customer_rfc
+msgid "The customer tax identification number."
+msgstr "Número de idenfificación fiscal del cliente"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model.fields,help:s_l10n_mx_edi_suppliers.field_hr_expense__l10n_mx_edi_cfdi_supplier_rfc
+msgid "The supplier tax identification number."
+msgstr "Número de idenfificación fiscal del proveedor"
+
+#. module: s_l10n_mx_edi_suppliers
+#: model:ir.model,name:s_l10n_mx_edi_suppliers.model_l10n_mx_edi_uuid_verification_tools
+msgid "UUID verification mixin"
+msgstr ""
+
+#. module: s_l10n_mx_edi_suppliers
+#. odoo-python
+#: code:addons/s_l10n_mx_edi_suppliers/models/inherit_account_move.py:0
+#, python-format
+msgid "Update of the SAT status has no changes: \"%(msg)s\""
+msgstr "Actualización del estado del SAT sin cambios: \"%(msg)s\""
 
 #. module: s_l10n_mx_edi_suppliers
 #: model:ir.model.fields,field_description:s_l10n_mx_edi_suppliers.field_res_company__vendor_bills_status_notification_user_ids
@@ -135,11 +213,6 @@ msgid ""
 msgstr ""
 "Usuarios a notificar cuando cambia el estado de las facturas de proveedores "
 "en el SAT"
-
-#. module: s_l10n_mx_edi_suppliers
-#: model:ir.model.fields.selection,name:s_l10n_mx_edi_suppliers.selection__account_move__l10n_mx_edi_sat_status_supplier__valid
-msgid "Valid"
-msgstr "Válido"
 
 #. module: s_l10n_mx_edi_suppliers
 #. odoo-python

--- a/s_l10n_mx_edi_suppliers/models/__init__.py
+++ b/s_l10n_mx_edi_suppliers/models/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from . import uuid_verification_tools
 from . import inherit_account_move
 from . import inherit_res_config_settings
+from . import inherit_hr_expense

--- a/s_l10n_mx_edi_suppliers/models/inherit_hr_expense.py
+++ b/s_l10n_mx_edi_suppliers/models/inherit_hr_expense.py
@@ -1,0 +1,137 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import float_repr
+import re
+
+
+class AccountMove(models.Model):
+    _name = "hr.expense"
+    _inherit = ["hr.expense", "l10n.mx.edi.uuid.verification.tools"]
+
+    l10n_mx_edi_cfdi_uuid = fields.Char(
+        string='Fiscal Folio', copy=False,
+        help='Folio in electronic invoice, is returned by SAT when send to stamp.',
+    )
+    l10n_mx_edi_sat_status = fields.Selection(
+        selection=lambda self: self.env['account.move']._fields['l10n_mx_edi_sat_status'].selection,
+        string='Sat status',
+        default='none'
+    )
+    l10n_mx_edi_status_change_date = fields.Date(
+        'Status change date'
+    )
+    l10n_mx_edi_cfdi_supplier_rfc = fields.Char(
+        string='Supplier RFC',
+        copy=False,
+        readonly=True,
+        help='The supplier tax identification number.',
+        compute='_compute_cfdi_values')
+    l10n_mx_edi_cfdi_customer_rfc = fields.Char(
+        string='Customer RFC',
+        copy=False,
+        readonly=True,
+        help='The customer tax identification number.',
+        compute='_compute_cfdi_values')
+
+    l10n_mx_edi_status_change_date_supplier = fields.Date(
+        'Status change date'
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Si se establece el uuid el estado SAT en no definido
+        hasta tanto no se verifique contra el SAT
+        """
+        for vals in vals_list:
+            if 'l10n_mx_edi_cfdi_uuid' in vals and vals.get('l10n_mx_edi_cfdi_uuid', False):
+                vals.update({
+                    'l10n_mx_edi_sat_status': 'none',
+                    'l10n_mx_edi_status_change_date_supplier': False,
+                })
+        return super().create(vals)
+
+    def write(self, vals):
+        """
+        Si se establece el uuid el estado SAT en no definido
+        hasta tanto no se verifique contra el SAT
+        """
+        if 'l10n_mx_edi_cfdi_uuid' in vals and vals.get('l10n_mx_edi_cfdi_uuid', False):
+            vals.update({
+                'l10n_mx_edi_sat_status': 'none',
+                'l10n_mx_edi_status_change_date_supplier': False,
+            })
+        return super().write(vals)
+
+    @api.constrains('l10n_mx_edi_cfdi_uuid')
+    def constrains_l10n_mx_edi_cfdi_uuid_(self):
+        """
+        Validaciones asociadas al cfdi de las facturas de proveedor
+        """
+        self.check_l10n_mx_edi_cfdi_uuid()
+        for rec in self:
+            def on_error(ex):
+                raise ValidationError(
+                    _("Failure during update of the SAT status: %(msg)s") % {
+                        "msg": str(ex)
+                    }
+                )
+            status = rec.get_l10n_mx_edi_uuid_sat_status(on_error)
+            if status != 'Vigente':
+                raise ValidationError(
+                    _('Invoice SAT status is: "%(msg)s"') % {
+                        "msg": status
+                    }
+                )
+
+    def _compute_cfdi_values(self):
+        for rec in self:
+            rec.l10n_mx_edi_cfdi_supplier_rfc = ''
+            rec.l10n_mx_edi_cfdi_customer_rfc = self.env.company.vat
+
+    def action_update_vendor_sat_status(self):
+        self.l10n_mx_edi_update_vendor_sat_status()
+
+    def l10n_mx_edi_update_vendor_sat_status(self):
+        '''
+        Validar que los uuids de las facturas de proveedores son válidos.
+        Si cambia de estado y se indican usuarios, notificarlos
+        '''
+
+        for move in self:
+            def on_error(ex):
+                move.message_post(
+                    body=_("Failure during update of the SAT status: %(msg)s", msg=str(ex)))
+
+            status = move.get_l10n_mx_edi_uuid_sat_status(on_error)
+            if status:
+                new_status = move.get_l10n_mx_edi_status_from_sat_status(
+                    status)
+                old_status = move.l10n_mx_edi_sat_status
+                description_selection_dict = dict(
+                    self.env[self._name]._fields['l10n_mx_edi_sat_status']._description_selection(self.with_context(lang=self.env.user.lang).env))
+                if new_status != old_status:
+                    move.l10n_mx_edi_sat_status = new_status
+                    move.l10n_mx_edi_status_change_date_supplier = fields.Date.today()
+                    move.message_post(
+                        body=_('Status for the invoice change from "%s" to "%s"') % (
+                            _(description_selection_dict[old_status]),
+                            _(description_selection_dict[new_status])
+                        ),
+                    )
+
+    def get_l10n_mx_edi_cfdi_supplier_rfc(self):
+        return self.l10n_mx_edi_cfdi_supplier_rfc
+
+    def get_l10n_mx_edi_cfdi_customer_rfc(self):
+        return self.l10n_mx_edi_cfdi_customer_rfc
+
+    def get_l10n_mx_edi_cfdi_amount(self):
+        return float_repr(self.total_amount,
+                          precision_digits=self.currency_id.decimal_places)
+
+    def get_l10n_mx_edi_cfdi_uuid(self):
+        return self.l10n_mx_edi_cfdi_uuid
+
+    def get_l10n_mx_edi_cfdi_unique_uuid_domain(self):
+        return [('id', '!=', self.id), ('l10n_mx_edi_cfdi_uuid', '=', self.l10n_mx_edi_cfdi_uuid)]

--- a/s_l10n_mx_edi_suppliers/models/uuid_verification_tools.py
+++ b/s_l10n_mx_edi_suppliers/models/uuid_verification_tools.py
@@ -1,0 +1,93 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import float_repr
+import re
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class UIIDVerificationMixin(models.AbstractModel):
+    _name = 'l10n.mx.edi.uuid.verification.tools'
+    _description = 'UUID verification mixin'
+
+    def check_l10n_mx_edi_cfdi_uuid(self):
+        """
+        Validaciones locales asociadas al cfdi es necesario adicionar el constrains en los modelos que heredan de este
+        """
+        for rec in self:
+            # Si es una factura de proveedor, no tiene un cfdi asociado
+            #  y está establecido el l10n_mx_edi_cfdi_uuid_supplier
+            rec_uuid = rec.get_l10n_mx_edi_cfdi_uuid()
+            if rec_uuid:
+                # El uuid solo debe contener números del 0-9 y letas mayúsculas
+                # de la A-F en el formato "12A3BCD-4EFA-56B7-C891-23D4E56F7ABC"
+                regex = r"^[ABCDEF0-9]{7}[-]{1}([ABCDEF0-9]{4}[-]{1}){3}[ABCDEF0-9]{12}$"
+                if not re.match(regex, rec_uuid):
+                    raise ValidationError(
+                        _('Invoice UUID structure is invalid, must contain uppercase letters A through F and numbers 0 through 9 in the format "12A3BCD-4EFA-56B7-C891-23D4E56F7ABC"')
+                    )
+
+                # Validar que el cfdi no esté asociado a otro registro
+                unique_uuid_domain = rec.get_l10n_mx_edi_cfdi_unique_uuid_domain()
+                if self.search_count(unique_uuid_domain):
+                    raise ValidationError(_("Invoice UUID already registered"))
+
+    # Métodos auxiliares, para un solo registro
+
+    def get_l10n_mx_edi_uuid_sat_status(self, on_get_sat_status_error=None):
+        """
+        Obtener el estado de un registro en el sat
+        """
+        self.ensure_one()
+        supplier_rfc = self.get_l10n_mx_edi_cfdi_supplier_rfc()
+        customer_rfc = self.get_l10n_mx_edi_cfdi_customer_rfc()
+        total = self.get_l10n_mx_edi_cfdi_amount()
+        uuid = self.get_l10n_mx_edi_cfdi_uuid()
+
+        try:
+            status = self.env['account.edi.format']._l10n_mx_edi_get_sat_status(
+                supplier_rfc, customer_rfc, total, uuid)
+        except Exception as e:
+            if on_get_sat_status_error:
+                on_get_sat_status_error(e)
+            else:
+                _logger.error(_("Failure during update of the SAT status: %(msg)s") % {
+                    "msg": str(e)
+                })
+
+            return None
+        return status
+
+    def get_l10n_mx_edi_status_from_sat_status(self, sat_status):
+        """
+        Obtener l10n_mx_edi_status a partir del estado del SAT
+        """
+        sat_l10n_mx_edi_status_dict = {
+            'Vigente': 'valid',
+            'Cancelado': 'cancelled',
+            'No Encontrado': 'not_found'
+        }
+        if sat_status in sat_l10n_mx_edi_status_dict:
+            return sat_l10n_mx_edi_status_dict[sat_status]
+        return 'none'
+
+    def get_l10n_mx_edi_cfdi_supplier_rfc(self):
+        # To override
+        pass
+
+    def get_l10n_mx_edi_cfdi_customer_rfc(self):
+        # To override
+        pass
+
+    def get_l10n_mx_edi_cfdi_amount(self):
+        # To override
+        pass
+
+    def get_l10n_mx_edi_cfdi_uuid(self):
+        # To override
+        pass
+
+    def get_l10n_mx_edi_cfdi_unique_uuid_domain(self):
+        # To override
+        pass

--- a/s_l10n_mx_edi_suppliers/views/inherit_account_move.xml
+++ b/s_l10n_mx_edi_suppliers/views/inherit_account_move.xml
@@ -6,31 +6,29 @@
             <field name="model">account.move</field>
             <field name="inherit_id" ref="account.view_move_form" />
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='payment_reference']" position="after">
+
+                <xpath expr="//field[@name='ref']" position="after">
                     <field name="has_cfdi" invisible="1" />
-
                     <field name="l10n_mx_edi_cfdi_uuid_supplier"
-                        string="Fiscal Folio"
+                        string="Invoice UUID"
                         attrs="{'invisible': ['|', ('move_type', '!=', 'in_invoice'), ('has_cfdi', '=', True) ] }" />
+                </xpath>
 
+                <xpath expr="//field[@name='payment_reference']" position="after">
                     <label for="l10n_mx_edi_sat_status_supplier"
                         attrs="{'invisible': ['|', ('l10n_mx_edi_cfdi_uuid_supplier', 'in', [False, None, ''] ), ('has_cfdi', '=', True)] }" />
                     <div class="o_row"
                         attrs="{'invisible': ['|', ('l10n_mx_edi_cfdi_uuid_supplier', 'in', [False, None, ''] ),('has_cfdi', '=', True)] }">
                         <field name="l10n_mx_edi_sat_status_supplier" />
-
                         <button name="action_update_vendor_sat_status" type="object"
                             string="" class="oe_link"
-                            attrs="{'invisible': ['|', ('l10n_mx_edi_sat_status_supplier', '!=', 'undefined'), ('has_cfdi', '=', True)]}">
+                            attrs="{'invisible': ['|', ('l10n_mx_edi_cfdi_uuid_supplier', 'in', [False, None, ''] ),('has_cfdi', '=', True)] }">
                             <i title="Check" role="img" aria-label="Check"
                                 class="fa fa-refresh" /> Check </button>
                     </div>
-
-
                     <field name="l10n_mx_edi_status_change_date_supplier"
                         readonly="1"
                         attrs="{'invisible': [('l10n_mx_edi_cfdi_uuid_supplier', 'in', [False, None, ''] )] }" />
-
                 </xpath>
             </field>
         </record>

--- a/s_l10n_mx_edi_suppliers/views/inherit_hr_expense.xml
+++ b/s_l10n_mx_edi_suppliers/views/inherit_hr_expense.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_hr_expense_view_form" model="ir.ui.view">
+            <field name="name">s.inherit.hr.expense.view.form</field>
+            <field name="model">hr.expense</field>
+            <field name="inherit_id" ref="hr_expense.hr_expense_view_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='reference']" position="after">
+                    <field name="l10n_mx_edi_cfdi_uuid"
+                        string="Invoice UUID" />
+
+                    <label for="l10n_mx_edi_sat_status"
+                        attrs="{'invisible': [('l10n_mx_edi_cfdi_uuid', 'in', [False, None, ''] )] }" />
+                    <div class="o_row"
+                        attrs="{'invisible': [('l10n_mx_edi_cfdi_uuid', 'in', [False, None, ''] )] }">
+                        <field name="l10n_mx_edi_sat_status" readonly="1" />
+                        <button name="action_update_vendor_sat_status" type="object"
+                            string="" class="oe_link">
+                            <i title="Check" role="img" aria-label="Check"
+                                class="fa fa-refresh" /> Check </button>
+                    </div>
+                    <field name="l10n_mx_edi_status_change_date"
+                        readonly="1"
+                        attrs="{'invisible': [('l10n_mx_edi_cfdi_uuid', 'in', [False, None, ''] )] }" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Campos para el uuid en los gastos
Crear mixin para las validaciones del uuid y evitar código duplicado Expresión regular para validar que el formato del uuid sea correcto Validar que el uuid no exista asociado a otro registro Validar en el momento en que el estado en el sat sea correcto