### PR TITLE
TEST: Ventas – Tipos de Proyecto

### DIFF
--- a/s_sale_docs/__init__.py
+++ b/s_sale_docs/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/s_sale_docs/__manifest__.py
+++ b/s_sale_docs/__manifest__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Sale Attachments",
+    'summary': """Manage Attachments for Sale Orders""",
+    'description': """
+        Manage attachments for sales orders, document settings by type, optional and required documents
+    """,
+    'author': "SUITEDOO",
+    'website': "https://www.suitedoo.com",
+    'category': 'Sales/Sales',
+    'version': '0.1',
+    'depends': ['sale'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/sale_project_views.xml',
+        'views/inherit_sale_order_views.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            's_sale_docs/static/src/js/relational_util.js',
+        ]
+    },
+    'demo': [],
+    'installable': True,
+    'auto_install': False,
+    'application': False
+}

--- a/s_sale_docs/i18n/es_MX.po
+++ b/s_sale_docs/i18n/es_MX.po
@@ -1,0 +1,250 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* s_sale_docs
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-08-12 04:08+0000\n"
+"PO-Revision-Date: 2023-08-12 04:08+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: s_sale_docs
+#. odoo-python
+#: code:addons/s_sale_docs/models/sale_project.py:0
+#, python-format
+msgid "%(name)s (archive %(extension)s)"
+msgstr "%(name)s (archivo %(extension)s)"
+
+#. module: s_sale_docs
+#: model_terms:ir.ui.view,arch_db:s_sale_docs.s_inherit_project_type_view_order_form
+msgid "Attachment"
+msgstr "Adjunto"
+
+#. module: s_sale_docs
+#. odoo-python
+#: code:addons/s_sale_docs/models/inherit_sale_order.py:0
+#, python-format
+msgid "Attachment %s is required"
+msgstr "El adjunto %s es requerido"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__attachment_file
+msgid "Attachment file"
+msgstr "Fichero adjunto"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__attachment_required_str
+msgid "Attachment required string"
+msgstr "Texto adjunto requerido"
+
+#. module: s_sale_docs
+#: model:ir.model,name:s_sale_docs.model_sale_project_attachment_type
+msgid "Attachment type"
+msgstr "Tipo de adjunto"
+
+#. module: s_sale_docs
+#: model:ir.model.constraint,message:s_sale_docs.constraint_sale_project_attachment_config_unique_attachment_type_by_project_type
+msgid "Attachment type can not be repeated by project type"
+msgstr "El tipo de adjunto no se puede repetir por tipo de proyecto"
+
+#. module: s_sale_docs
+#: model:ir.actions.act_window,name:s_sale_docs.s_sale_order_document_type_action
+#: model:ir.ui.menu,name:s_sale_docs.s_sale_order_document_type_menu
+msgid "Attachment types"
+msgstr "Tipos de adjunto"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order__project_attachment_ids
+#: model_terms:ir.ui.view,arch_db:s_sale_docs.s_sale_project_type_view_form0
+msgid "Attachments"
+msgstr "Adjuntos"
+
+#. module: s_sale_docs
+#. odoo-python
+#: code:addons/s_sale_docs/models/inherit_sale_order.py:0
+#, python-format
+msgid "Attachments %s are required"
+msgstr "Los adjuntos %s son requeridos"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__attachment_config_ids
+msgid "Attachments documents"
+msgstr "Documentos adjuntos"
+
+#. module: s_sale_docs
+#: model:ir.model,name:s_sale_docs.model_sale_project_attachment_config
+msgid "Configuration for Types of Sales Order Attachment"
+msgstr "Configuración para los tipos de adjuntos de las órdenes de venta"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,help:s_sale_docs.field_sale_project_type__attachment_config_ids
+msgid ""
+"Configuration for documents that will be attachet to a sale orders of this "
+"type"
+msgstr ""
+"Configuración para los documentos que serán adjuntados a las órdenes de "
+"venta de este tipo"
+
+#. module: s_sale_docs
+#: model_terms:ir.actions.act_window,help:s_sale_docs.s_sale_order_document_type_action
+msgid "Create new attachment type"
+msgstr "Crear un nuevo tipo de adjunto"
+
+#. module: s_sale_docs
+#: model_terms:ir.actions.act_window,help:s_sale_docs.s_sale_project_type_action
+msgid "Create new project type"
+msgstr "Crear un nuevo tipo de proyecto"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__create_uid
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__create_uid
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__create_uid
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__create_date
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__create_date
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__create_date
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__display_name
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__display_name
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__display_name
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__attachment_file_name
+msgid "Filename"
+msgstr "Nombre de archivo"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__id
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__id
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__id
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__id
+msgid "ID"
+msgstr ""
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment____last_update
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config____last_update
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type____last_update
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__write_uid
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__write_uid
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__write_uid
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__write_date
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__write_date
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__write_date
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__name
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__document_name
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__name
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_type__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: s_sale_docs
+#: model:ir.ui.menu,name:s_sale_docs.s_sale_project_menu
+msgid "Project"
+msgstr "Proyecto"
+
+#. module: s_sale_docs
+#: model:ir.actions.act_window,name:s_sale_docs.s_sale_project_type_action
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order__project_type_id
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__project_type_id
+#: model_terms:ir.ui.view,arch_db:s_sale_docs.s_sale_order_document_type_view_tree
+#: model_terms:ir.ui.view,arch_db:s_sale_docs.s_sale_project_type_view_tree
+msgid "Project Type"
+msgstr "Tipo de proyecto"
+
+#. module: s_sale_docs
+#: model:ir.ui.menu,name:s_sale_docs.s_sale_project_type_menu
+msgid "Project type"
+msgstr "Tipo de proyecto"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__attachment_required
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__attachment_required
+msgid "Required"
+msgstr "Requerido"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__sale_order_id
+msgid "Sale Order"
+msgstr "Orden de venta"
+
+#. module: s_sale_docs
+#: model:ir.model,name:s_sale_docs.model_sale_order_attachment
+msgid "Sale Order Attachment"
+msgstr "Adjunto de la orden de venta"
+
+#. module: s_sale_docs
+#: model:ir.model,name:s_sale_docs.model_sale_order
+msgid "Sales Order"
+msgstr "Orden de venta"
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_order_attachment__document_type_id
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_config__document_type_id
+msgid "Type"
+msgstr "Tipo "
+
+#. module: s_sale_docs
+#: model:ir.model.fields,field_description:s_sale_docs.field_sale_project_attachment_type__document_type
+msgid "Type (extension)"
+msgstr "Tipo (extensión)"
+
+#. module: s_sale_docs
+#: model:ir.model,name:s_sale_docs.model_sale_project_type
+msgid "Type of Sales Project"
+msgstr "Tipo de proyecto de venta"
+
+#. module: s_sale_docs
+#: model_terms:ir.ui.view,arch_db:s_sale_docs.s_inherit_project_type_view_order_form
+msgid "Update"
+msgstr "Actualizar"
+
+#. module: s_sale_docs
+#: model_terms:ir.ui.view,arch_db:s_sale_docs.s_inherit_project_type_view_order_form
+msgid "Upload"
+msgstr "Subir"
+
+#. module: s_sale_docs
+#. odoo-python
+#: code:addons/s_sale_docs/models/sale_order_attachment.py:0
+#, python-format
+msgid "You must provide file name for attachment."
+msgstr "Debe proporcionar el nombre del fichero para el adjunto"
+
+#. module: s_sale_docs
+#: model_terms:ir.ui.view,arch_db:s_sale_docs.s_sale_order_document_type_view_form
+msgid "xls, pdf, dox, dwg"
+msgstr ""

--- a/s_sale_docs/models/__init__.py
+++ b/s_sale_docs/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_project
+from . import sale_order_attachment
+from . import inherit_sale_order
+

--- a/s_sale_docs/models/inherit_sale_order.py
+++ b/s_sale_docs/models/inherit_sale_order.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api, Command, _
+from odoo.exceptions import ValidationError
+from odoo.addons.sale.models.sale_order import READONLY_FIELD_STATES
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    project_type_id = fields.Many2one(
+        'sale.project.type',
+        string='Project Type',
+        ondelete='restrict',
+        states=READONLY_FIELD_STATES
+    )
+
+    project_attachment_ids = fields.One2many(
+        'sale.order.attachment',
+        'sale_order_id',
+        string='Attachments',
+        states=READONLY_FIELD_STATES
+    )
+
+    @api.onchange('project_type_id')
+    def _onchange_project_type_id(self):
+        """
+        Establecer los adjuntos del tipo de proyecto cuando este cambie
+        """
+        self.ensure_one()
+        self.project_attachment_ids = [Command.clear()]
+        att_commands = []
+        for attachment_config in self.project_type_id.attachment_config_ids:
+            att_commands.append(Command.create({
+                'document_type_id': attachment_config.document_type_id.id,
+                'attachment_required': attachment_config.attachment_required
+            }))
+        if att_commands:
+            self.project_attachment_ids = att_commands
+
+    def action_confirm(self):
+        """
+        Si existen adjuntos requeridos vacios no se puede confirmar la orden
+        """
+        if self.project_type_id:
+            empty_required_attachments = self.project_attachment_ids.filtered(
+                lambda x: x.attachment_required and not x.attachment_file)
+            if empty_required_attachments:
+                if len(empty_required_attachments) > 1:
+                    error_msg = _("Attachments %s are required") % ','.join(
+                        [att.document_type_id.name for att in empty_required_attachments]
+                    )
+                else:
+                    error_msg = _(
+                        "Attachment %s is required") % empty_required_attachments[0].document_type_id.name
+            raise ValidationError(error_msg)
+        return super().action_confirm()

--- a/s_sale_docs/models/sale_order_attachment.py
+++ b/s_sale_docs/models/sale_order_attachment.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SaleOrderAttachment(models.Model):
+    _name = 'sale.order.attachment'
+    _description = 'Sale Order Attachment'
+    _rec_name = 'attachment_file_name'
+    _order = 'attachment_required desc'
+
+    sale_order_id = fields.Many2one(
+        'sale.order',
+        string='Sale Order',
+        required=False,
+        ondelete='cascade'
+    )
+    name = fields.Char(compute='_compute_name', string='Name')
+    attachment_required = fields.Boolean('Required')
+    attachment_required_str = fields.Char(
+        compute='_compute_attachment_required_str',
+        string='Attachment required string'
+    )
+    attachment_file = fields.Binary(
+        'Attachment file',
+        attachment=True
+    )
+    attachment_file_name = fields.Char('Filename')
+    document_type_id = fields.Many2one(
+        'sale.project.attachment.type',
+        'Type',
+        required=True,
+        ondelete='restrict'
+    )
+
+    @api.depends('attachment_required')
+    def _compute_attachment_required_str(self):
+        for rec in self:
+            rec.attachment_required_str = "*" if rec.attachment_required else ""
+
+    @api.depends('attachment_file_name', 'document_type_id')
+    def _compute_name(self):
+        for rec in self:
+            rec.name = "% : %" % (
+                rec.document_type_id.document_name, rec.attachment_file_name)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Modificar el adjunto del campo para establecer el nombre y tipo mime
+        y así poder adjuntarlo a la orden
+        """
+        res = super().create(vals_list)
+        i = 0
+        for rec in res:
+            rec.manage_attachment(vals_list[i])
+            i += 1
+        return res
+
+    def write(self, vals):
+        """
+        Modificar el adjunto del campo para establecer el nombre y tipo mime
+        y así poder adjuntarlo a la orden
+        """
+        res = super().write(vals)
+        for rec in self:
+            if vals.get('attachment_file', False):
+                self.manage_attachment(vals)
+        return res
+
+    def manage_attachment(self, vals):
+        """
+        Modificar el adjunto del campo para establecer el nombre y tipo mime
+        y así poder adjuntarlo a la orden
+        """
+        if vals.get('attachment_file', False):
+            attachment_file_name = vals.get(
+                'attachment_file_name', self.attachment_file_name)
+            if not attachment_file_name:
+                # Puede darse el caso de que se actualice el documento
+                # con una versión mas reciente y como el nombre no cambia no viene el vals
+                raise ValidationError(
+                    _("You must provide file name for attachment."))
+            mimetype = self.env['ir.attachment']._compute_mimetype({
+                'name': attachment_file_name
+            })
+            attachment = self.env['ir.attachment'].search([
+                ('res_model', '=', self._name),
+                ('res_field', '=', 'attachment_file'),
+                ('res_id', '=', self.id),
+            ])
+            if attachment:
+                updates = {
+                    'mimetype': mimetype
+                }
+                if attachment_file_name:
+                    updates.update({'name': attachment_file_name})
+                attachment.write(updates)
+
+                attachment_for_sale = attachment.copy({
+                    'res_model': 'sale.order',
+                    'res_id': self.sale_order_id.id,
+                })
+                self.sale_order_id.with_context({'mail_create_nosubscribe': True}).message_post(**{
+                    'attachment_ids': [attachment_for_sale.id],
+                    'body': '',
+                    'message_type': 'comment',
+                    'partner_ids': [],
+                    'subtype_xmlid': 'mail.mt_note'
+                })

--- a/s_sale_docs/models/sale_project.py
+++ b/s_sale_docs/models/sale_project.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api, _
+
+
+class SaleProjectDocumentType(models.Model):
+    _name = 'sale.project.attachment.type'
+    _description = 'Attachment type'
+
+    name = fields.Char(
+        compute='_compute_name',
+        string='Name',
+        store=False
+    )
+    document_name = fields.Char('Name', required=True)
+    document_type = fields.Char('Type (extension)', required=True)
+
+    @api.model
+    def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
+        """
+        Cuando se busque por el nombre, buscar en los elementos que lo componen
+        para que el campo siempre se calcule y salga en el idioma del usuario
+        evitando la traducción del campo por el usuario
+        """
+        new_args = []
+        for arg in args:
+            if len(arg) and arg[0] == 'name':
+                new_args.append('|')
+                new_args.append(('document_name', arg[1], arg[2]))
+                new_args.append(('document_type', arg[1], arg[2]))
+            else:
+                new_args.append(arg)
+        return super()._search(new_args, offset, limit, order, count, access_rights_uid)
+
+    @api.depends('document_name', 'document_type')
+    def _compute_name(self):
+        """
+        Calcular el nombre del tipo de adjunto en el formato:
+        "Planos (archivo .dwg)"
+        """
+        for rec in self:
+            doc_type = rec.document_type
+            if not doc_type.startswith('.'):
+                doc_type = '.' + doc_type
+            rec.name = _("%(name)s (archive %(extension)s)") % {
+                'name': rec.document_name,
+                'extension': doc_type
+            }
+
+
+class SaleOrderAttachmentConfig(models.Model):
+    _name = 'sale.project.attachment.config'
+    _description = 'Configuration for Types of Sales Order Attachment'
+    _rec_name = 'document_type_id'
+    _order = 'attachment_required desc'
+
+    _sql_constraints = [
+        (
+            'unique_attachment_type_by_project_type',
+            'UNIQUE(project_type_id, document_type_id)',
+            'Attachment type can not be repeated by project type',
+        ),
+    ]
+
+    project_type_id = fields.Many2one(
+        'sale.project.type',
+        required=True,
+        ondelete='restrict'
+    )
+    document_type_id = fields.Many2one(
+        'sale.project.attachment.type',
+        'Type',
+        required=True,
+        ondelete='restrict'
+    )
+    attachment_required = fields.Boolean(
+        'Required',
+        default=True
+    )
+
+
+class ProjectType(models.Model):
+    _name = 'sale.project.type'
+    _description = 'Type of Sales Project'
+
+    name = fields.Char('Name')
+    attachment_config_ids = fields.One2many(
+        'sale.project.attachment.config',
+        'project_type_id',
+        string='Attachments documents',
+        help='Configuration for documents that will be attachet to a sale orders of this type'
+    )

--- a/s_sale_docs/security/ir.model.access.csv
+++ b/s_sale_docs/security/ir.model.access.csv
@@ -1,0 +1,13 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_project_type_all,sale.project.type.all,model_sale_project_type,,1,0,0,0
+access_sale_project_type_manager,sale.project.type.manager,model_sale_project_type,sales_team.group_sale_manager,1,1,1,1
+
+access_sale_project_attachment_type_all,sale.project.attachment.type.all,model_sale_project_attachment_type,,1,0,0,0
+access_sale_project_attachment_type_manager,sale.project.attachment.type.manager,model_sale_project_attachment_type,sales_team.group_sale_manager,1,1,1,1
+
+access_sale_project_attachment_config_all,sale.project.attachment.config.all,model_sale_project_attachment_config,,1,0,0,0
+access_sale_project_attachment_config_manager,sale.project.attachment.config.manager,model_sale_project_attachment_config,sales_team.group_sale_manager,1,1,1,1
+
+access_sale_order_attachment_all,sale.order.attachment.all,model_sale_order_attachment,,1,1,1,1
+
+

--- a/s_sale_docs/static/src/js/relational_util.js
+++ b/s_sale_docs/static/src/js/relational_util.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+import { X2ManyFieldDialog } from "@web/views/fields/relational_utils";
+import { patch } from "@web/core/utils/patch";
+
+patch(X2ManyFieldDialog.prototype, "sale_order_attachment_prevent_create_and_new_button", {
+    setup() {
+        this._super(...arguments);
+        if (this.record.resModel == 'sale.order.attachment') {
+            this.canCreate = false;
+        }
+    }
+});

--- a/s_sale_docs/views/inherit_sale_order_views.xml
+++ b/s_sale_docs/views/inherit_sale_order_views.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+
+    <record id="s_inherit_project_type_view_order_form" model="ir.ui.view">
+      <field name="name">s.inherit.project.type.view.order.form</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale.view_order_form" />
+      <field name="arch" type="xml">
+        <xpath expr="//group[@name='sale_header']/group[@name='partner_details']" position="inside">
+          <field name="project_type_id" options="{'no_create':true,'no_open':true}" />
+        </xpath>
+
+        <xpath expr="//notebook[1]" position="before">
+          <div>
+            <field
+              name="project_attachment_ids"
+              mode="kanban"
+              no_label="1"
+              options="{'no_create': true, 'no_create_edit': true}"
+              attrs="{'invisible': [('project_type_id', 'in', [False, None, ''])]}">
+              <kanban
+                delete="false"
+                create="false">
+                <field name="document_type_id" />
+                <field name="attachment_file" />
+                <field name="attachment_file_name" />
+                <field name="attachment_required" />
+                <field name="attachment_required_str" />
+                <templates>
+                  <t t-name="kanban-box">
+                    <field name="attachment_file" invisible="1" />
+                    <field name="attachment_required" invisible="1" />
+                    <div class="oe_kanban_global_click">
+                      <a
+                        class="btn btn-primary oe_right"
+                        role="button"
+                        attrs="{'invisible': [('attachment_file', '!=', False)]}"
+                        onclick="$(this).closest('.oe_kanban_global_click').click()">
+                        Upload
+                      </a>
+                      <a
+                        class="btn btn-primary oe_right"
+                        role="button"
+                        attrs="{'invisible': [('attachment_file', '=', False)]}"
+                        onclick="$(this).closest('.oe_kanban_global_click').click()">
+                        Update
+                      </a>
+                      <field name="attachment_required_str" />
+                      <field name="document_type_id" />
+                      <br />
+                      <field name="attachment_file_name"
+                        attrs="{'invisible': [('attachment_file_name', '=', False)]}" />
+                    </div>
+                  </t>
+                </templates>
+              </kanban>
+
+              <form delete="false" create="false" string="Attachment">
+                <h3 class="d-inline-block">
+                  <field name="document_type_id"
+                    nolabel="1"
+                    readonly="1"
+                    options="{'no_open': true}" />
+                </h3>
+                <field
+                  name="attachment_file"
+                  widget="binary"
+                  filename="attachment_file_name"
+                  nolabel="1"
+                  class="d-inline-block ms-3"
+                />
+                <group>
+                  <field name="attachment_file_name" invisible="1" />
+                  <!-- Para evitar que se pueda usar el boton guardar y nuevo del wizard -->
+                  <field name="document_type_id" invisible="1" required="1" />
+                </group>
+              </form>
+            </field>
+          </div>
+        </xpath>
+      </field>
+    </record>
+
+  </data>
+</odoo>

--- a/s_sale_docs/views/sale_project_views.xml
+++ b/s_sale_docs/views/sale_project_views.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+    <!-- Tipos de documento -->
+    <record id="s_sale_order_document_type_view_tree" model="ir.ui.view">
+      <field name="name">s.sale.project.attachment.type.view.tree</field>
+      <field name="model">sale.project.attachment.type</field>
+      <field name="arch" type="xml">
+        <tree string="Project Type">
+          <field name="name" />
+        </tree>
+      </field>
+    </record>
+
+    <record id="s_sale_order_document_type_view_form" model="ir.ui.view">
+      <field name="name">s.sale.project.attachment.type.view.form</field>
+      <field name="model">sale.project.attachment.type</field>
+      <field name="arch" type="xml">
+        <form string="">
+          <sheet>
+            <group>
+              <group>
+                <field name="document_name" />
+                <field name="document_type" placeholder="xls, pdf, dox, dwg" />
+              </group>
+              <group>
+              </group>
+            </group>
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <record id="s_sale_order_document_type_action" model="ir.actions.act_window">
+      <field name="name">Attachment types</field>
+      <field name="res_model">sale.project.attachment.type</field>
+      <field name="view_mode">tree,form</field>
+      <field name="help" type="html">
+        <p class="o_view_nocontent_smiling_face">
+          Create new attachment type
+        </p>
+      </field>
+    </record>
+
+    <!-- Tipos de proyecto -->
+    <record id="s_sale_project_type_view_tree" model="ir.ui.view">
+      <field name="name">s.sale.project.type.view.tree</field>
+      <field name="model">sale.project.type</field>
+      <field name="arch" type="xml">
+        <tree string="Project Type">
+          <field name="name" />
+        </tree>
+      </field>
+    </record>
+
+    <record id="s_sale_project_type_view_form0" model="ir.ui.view">
+      <field name="name">s.sale.project.type.view.form</field>
+      <field name="model">sale.project.type</field>
+      <field name="arch" type="xml">
+        <form string="">
+          <sheet>
+            <group>
+              <group>
+                <field name="name" />
+              </group>
+              <group>
+              </group>
+            </group>
+            <notebook>
+              <page name="attachments" string="Attachments">
+                <field name="attachment_config_ids">
+                  <tree editable="bottom" nolabel="1" colspan="2">
+                    <field name="document_type_id" options="{'no_create':true,'no_open':true}" />
+                    <field name="attachment_required" />
+                  </tree>
+                </field>
+              </page>
+            </notebook>
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <record id="s_sale_project_type_action" model="ir.actions.act_window">
+      <field name="name">Project Type</field>
+      <field name="res_model">sale.project.type</field>
+      <field name="view_mode">tree,form</field>
+      <field name="help" type="html">
+        <p class="o_view_nocontent_smiling_face">
+          Create new project type
+        </p>
+      </field>
+    </record>
+
+    <menuitem
+      id="s_sale_project_menu"
+      name="Project"
+      parent="sale.menu_sale_config"
+      sequence="20" />
+
+    <menuitem
+      id="s_sale_order_document_type_menu"
+      name="Attachment types"
+      action="s_sale_docs.s_sale_order_document_type_action"
+      parent="s_sale_docs.s_sale_project_menu"
+      sequence="1" />
+
+    <menuitem
+      id="s_sale_project_type_menu"
+      name="Project type"
+      action="s_sale_docs.s_sale_project_type_action"
+      parent="s_sale_docs.s_sale_project_menu"
+      sequence="2" />
+
+  </data>
+</odoo>


### PR DESCRIPTION
Nomencladores para tipos de documentos
Nomenclador para tipo de proyecto, en este se configuran los documentos que lleva el proyecto y si son requeridos o no Generar los adjuntos cuando cambia el tipo de proyecto de la orden de ventas Vista kanban combinada con formulario para visualizar y subir los adjuntos Adjuntar los ficheros que se suben al chatter de la orden Validar que no se pueda confirmar la orden si está establecido el tipo de proyecto y existen adjuntos requeridos que no han sido subidos