### PR TITLE
TEST: Cobros – Tipo de Cambio

### DIFF
--- a/s_custom_sale_rate/__manifest__.py
+++ b/s_custom_sale_rate/__manifest__.py
@@ -10,6 +10,7 @@
     'depends': ['sale'],
     'data': [
         'security/ir.model.access.csv',
+        'data/decimal_precision.xml',
         'views/inherit_sale_order.xml',
         'views/inherit_account_move.xml',
     ],

--- a/s_custom_sale_rate/data/decimal_precision.xml
+++ b/s_custom_sale_rate/data/decimal_precision.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="decimal_manual_rate_for_sales" model="decimal.precision">
+            <field name="name">Manual exchange rate for sales</field>
+            <field name="digits" eval="4"/>
+        </record>
+    </data>
+</odoo>

--- a/s_custom_sale_rate/models/inherit_sale_order.py
+++ b/s_custom_sale_rate/models/inherit_sale_order.py
@@ -27,7 +27,8 @@ class SaleOrder(models.Model):
     manual_rate = fields.Float(
         'Exchange Rate',
         default=0,
-        states=READONLY_FIELD_STATES
+        states=READONLY_FIELD_STATES, 
+        digits='Manual exchange rate for sales'
     )
 
     @api.model_create_multi


### PR DESCRIPTION
Adicionar data noupdate=1 con precisión decimal para usar en la tasa de cambio personalizada de las órdenes de venta