### PR TITLE
TEST: Purchase credit

### DIFF
--- a/s_purchase_credit/__init__.py
+++ b/s_purchase_credit/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/s_purchase_credit/__manifest__.py
+++ b/s_purchase_credit/__manifest__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Credits limit for providers",
+    'summary': """
+        Manage credit limit for providers
+    """,
+    'description': """
+        Manage credit limit for providers
+    """,
+    'author': "SUITEDOO",
+    'website': "https://www.suitedoo.com",
+    'category': 'Inventory/Purchase',
+    'version': '0.1',
+    'depends': ['purchase'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/inherit_res_partner.xml',
+        'views/inherit_purchase_order.xml',
+    ],
+    'demo': [],
+    'installable': True,
+    'auto_install': False,
+    'application': False
+}

--- a/s_purchase_credit/i18n/es_MX.po
+++ b/s_purchase_credit/i18n/es_MX.po
@@ -1,0 +1,92 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* s_purchase_credit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-08-03 22:27+0000\n"
+"PO-Revision-Date: 2023-08-03 22:27+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: s_purchase_credit
+#. odoo-python
+#: code:addons/s_purchase_credit/models/inherit_purchase_order.py:0
+#, python-format
+msgid ""
+"%(provider)s reached its credit limit of %(credit_limit).2f. The available "
+"amount is %(available_amount).2f. If you wish to continue the order, it will"
+" be considered as a cash purchase."
+msgstr ""
+"%(provider)s alcanzó su límite de crédito de %(credit_limit).2f. El importe "
+"disponible es %(available_amount).2f. Si desea continuar, el pedido será "
+"considerado como una compra de contado."
+
+#. module: s_purchase_credit
+#: model:ir.model,name:s_purchase_credit.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: s_purchase_credit
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_partner__provider_amount_to_pay
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_users__provider_amount_to_pay
+msgid "Credit Amount To Pay"
+msgstr "Importe de crédito a pagar"
+
+#. module: s_purchase_credit
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_partner__provider_credit_control
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_users__provider_credit_control
+msgid "Credit Control"
+msgstr "Control de crédito"
+
+#. module: s_purchase_credit
+#: model_terms:ir.ui.view,arch_db:s_purchase_credit.s_inherit_view_partner_property_form_credit_control
+msgid "Credit to Pay"
+msgstr "Crédito por pagar"
+
+#. module: s_purchase_credit
+#: model_terms:ir.ui.view,arch_db:s_purchase_credit.s_inherit_view_partner_property_form_credit_control
+msgid "Maximum Credit"
+msgstr "Crédito máximo"
+
+#. module: s_purchase_credit
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_partner__provider_credit_max_amount
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_users__provider_credit_max_amount
+msgid "Maximum Credit Amount Allowed"
+msgstr "Monto máximo de crédito permitido"
+
+#. module: s_purchase_credit
+#: model:ir.model.fields,field_description:s_purchase_credit.field_purchase_order__provider_credit_limit_exceeded_msg
+msgid "Message for Provider Credit Limit Exceeded"
+msgstr "Mensaje de límite de crédito del proveedor excedido"
+
+#. module: s_purchase_credit
+#: model:ir.model.fields,field_description:s_purchase_credit.field_purchase_order__provider_credit_limit_exceeded
+msgid "Provider Credit Limit Exceeded"
+msgstr "Límite de crédito del proveedor excedido"
+
+#. module: s_purchase_credit
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_partner__provider_currency_id
+#: model:ir.model.fields,field_description:s_purchase_credit.field_res_users__provider_currency_id
+msgid "Provider Currency"
+msgstr "Divisa del proveedor"
+
+#. module: s_purchase_credit
+#: model:ir.model,name:s_purchase_credit.model_purchase_order
+msgid "Purchase Order"
+msgstr "Orden de compra"
+
+#. module: s_purchase_credit
+#. odoo-python
+#: code:addons/s_purchase_credit/models/inherit_res_partner.py:0
+#, python-format
+msgid "You must provide maximum credit amount when credit control is enabled"
+msgstr ""
+"Debe proporcionar el monto máximo de crédito cuando el control de crédito "
+"está habilitado"

--- a/s_purchase_credit/models/__init__.py
+++ b/s_purchase_credit/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import inherit_res_partner
+from . import inherit_purchase_order

--- a/s_purchase_credit/models/inherit_purchase_order.py
+++ b/s_purchase_credit/models/inherit_purchase_order.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from odoo import _, api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    provider_credit_limit_exceeded = fields.Boolean(
+        compute='_compute_provider_credit_limit_exceeded',
+        string='Provider Credit Limit Exceeded'
+    )
+
+    provider_credit_limit_exceeded_msg = fields.Char(
+        compute='_compute_provider_credit_limit_exceeded',
+        string='Message for Provider Credit Limit Exceeded'
+    )
+
+    @api.depends('partner_id', 'order_line')
+    def _compute_provider_credit_limit_exceeded(self):
+        """
+        Mensaje que se muestra cuando la orden excede el límite de crédito del proveedor
+        """
+        for order in self:
+            if order.partner_id.provider_credit_control and order.state != 'done':
+                partner_currency = order.partner_id.property_purchase_currency_id or self.env.company.currency_id
+                order_amount = order.currency_id._convert(
+                    from_amount=order.amount_total,
+                    to_currency=partner_currency,
+                    company=self.env.company,
+                    date=fields.Date.today(),
+                )
+                if order.partner_id.provider_amount_to_pay + order_amount > order.partner_id.provider_credit_max_amount:
+                    order.provider_credit_limit_exceeded = True
+                    order.provider_credit_limit_exceeded_msg = _("%(provider)s reached its credit limit of %(credit_limit).2f. The available amount is %(available_amount).2f. If you wish to continue the order, it will be considered as a cash purchase.") % {
+                        'provider': order.partner_id.name,
+                        'credit_limit': order.partner_id.provider_credit_max_amount,
+                        'available_amount': order.partner_id.provider_credit_max_amount - order.partner_id.provider_amount_to_pay
+                    }
+                    continue
+
+            order.provider_credit_limit_exceeded = False
+            order.provider_credit_limit_exceeded_msg = ""

--- a/s_purchase_credit/models/inherit_res_partner.py
+++ b/s_purchase_credit/models/inherit_res_partner.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    provider_credit_control = fields.Boolean('Credit Control')
+    provider_currency_id = fields.Many2one(
+        'res.currency',
+        compute='_compute_provider_currency_id',
+        string='Provider Currency'
+    )
+    provider_credit_max_amount = fields.Monetary(
+        'Maximum Credit Amount Allowed',
+        currency_field='provider_currency_id'
+    )
+    provider_amount_to_pay = fields.Monetary(
+        compute='_compute_credit_amount_to_pay',
+        currency_field='provider_currency_id',
+        string='Credit Amount To Pay',
+        store=False
+    )
+
+    @api.constrains('provider_credit_control')
+    def _constrains_provider_credit_control(self):
+        for partner in self:
+            if partner.provider_credit_control and not partner.provider_credit_max_amount:
+                raise ValidationError(
+                    _("You must provide maximum credit amount when credit control is enabled")
+                )
+
+    @api.depends('provider_credit_control', 'property_purchase_currency_id')
+    def _compute_provider_currency_id(self):
+        """
+        Modeda auxiliar para determinar el currency_field de los importes del control de crédito
+        """
+        for partner in self:
+            if partner.provider_credit_control:
+                partner.provider_currency_id = partner.property_purchase_currency_id or self.env.company.currency_id
+            else:
+                partner.provider_currency_id = False
+
+    @api.depends('property_purchase_currency_id', 'provider_credit_control', 'provider_credit_max_amount')
+    def _compute_credit_amount_to_pay(self):
+        for partner in self:
+            if partner.provider_credit_control and partner.provider_credit_max_amount:
+                partner_currency = partner.property_purchase_currency_id or self.env.company.currency_id
+
+                # En el onchange el id del registro es una instancia de models.NewId
+                partner_id = partner._origin.id if isinstance(
+                    partner.id, models.NewId) else partner.id
+
+                # Importe de las facturas en la modeda del proveedor
+                invoices = self.env['account.move'].search([
+                    ('move_type', '=', 'in_invoice'),
+                    ('partner_id', '=', partner_id),
+                    ('state', '=', 'posted')
+                ])
+                invoiced_amount = 0
+                for invoice in invoices:
+                    invoiced_amount += invoice.currency_id._convert(
+                        from_amount=invoice.amount_total,
+                        to_currency=partner_currency,
+                        company=self.env.company,
+                        date=invoice.date,
+                    )
+
+                # Importe de los pagos en la modeda del proveedor
+                paids = self.env['account.payment'].search([
+                    ('payment_type', '=', 'outbound'),
+                    ('partner_id', '=', partner_id),
+                    ('state', '=', 'posted')
+                ])
+                paid_amount = 0
+                for paid in paids:
+                    paid_amount += paid.currency_id._convert(
+                        from_amount=paid.amount,
+                        to_currency=partner_currency,
+                        company=self.env.company,
+                        date=paid.date,
+                    )
+
+                partner.provider_amount_to_pay = invoiced_amount - paid_amount
+            else:
+                partner.provider_amount_to_pay = 0

--- a/s_purchase_credit/security/ir.model.access.csv
+++ b/s_purchase_credit/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/s_purchase_credit/views/inherit_purchase_order.xml
+++ b/s_purchase_credit/views/inherit_purchase_order.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_purchase_order_credit_control_view_form" model="ir.ui.view">
+            <field name="name">s.inherit.purchase.order.credit.control.view.form</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//sheet" position="before">
+                    <group name="name">
+                        <field name="provider_credit_limit_exceeded" invisible="1" />
+                    </group>
+                    <div
+                        class="notification alert alert-warning"
+                        role="alert"
+                        attrs="{'invisible': [('provider_credit_limit_exceeded', '=', False)]}">
+                        <field
+                            name="provider_credit_limit_exceeded_msg"
+                            attrs="{'invisible': [('provider_credit_limit_exceeded', '=', False)]}" />
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/s_purchase_credit/views/inherit_res_partner.xml
+++ b/s_purchase_credit/views/inherit_res_partner.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="s_inherit_view_partner_property_form_credit_control" model="ir.ui.view">
+            <field name="name">s.inherit.view.partner.property.form.credit.control</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="purchase.view_partner_property_form" />
+            <field name="arch" type="xml">
+                <xpath
+                    expr="//field[@name='property_purchase_currency_id']"
+                    position="after">
+
+                    <field name="provider_currency_id" invisible="1" />
+                    <field name="provider_credit_control" />
+                    <field
+                        name="provider_credit_max_amount"
+                        string="Maximum Credit"
+                        widget="monetary"
+                        attrs="{'invisible': [('provider_credit_control', '=', False)]}" />
+                    <field
+                        name="provider_amount_to_pay"
+                        string="Credit to Pay"
+                        widget="monetary"
+                        attrs="{'invisible': [('provider_credit_control', '=', False)]}" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Adicionar campos para configurar el crédito de los proveesores Calcular importe a pagar teniendo en cuenta la divisa del proveedor de las facturas y de los pagos Mostrar advertencia si se sobrepasa el límite de crédito al crear la orden de compra